### PR TITLE
Define globals for Vite build

### DIFF
--- a/Leerdoelengenerator-main/vite.config.ts
+++ b/Leerdoelengenerator-main/vite.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  define: { global: 'globalThis', 'process.env': {} }
 });


### PR DESCRIPTION
## Summary
- define `global` and `process.env` in Vite config to satisfy libraries needing Node globals

## Testing
- `npm run lint` *(fails: unexpected any, unused vars)*
- `npm run build` *(fails: "geminiService" is not exported by "src/services/gemini.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68a33970ac2c8330a5df204f3db8cce0