### PR TITLE
Gracefully handle missing Gemini API key

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -269,7 +269,7 @@ function App() {
     // Duidelijke console‑log per pad
     console.log(
       "[AI-check] Lane:", lane,
-      "| Gemini beschikbaar?", geminiService.isAvailable?.() ?? false
+      "| Gemini beschikbaar?", geminiService.isAvailable()
     );
 
     try {
@@ -706,8 +706,12 @@ function App() {
                           value="baan2"
                           checked={lane === "baan2"}
                           onChange={() => setLane("baan2")}
+                          disabled={!geminiService.isAvailable()}
                         />
-                        <span>Baan 2 — met AI (werkrealistisch, gratis tools)</span>
+                        <span>
+                          Baan 2 — met AI (werkrealistisch, gratis tools)
+                          {!geminiService.isAvailable() && " (niet beschikbaar)"}
+                        </span>
                       </label>
                     </div>
                   </div>

--- a/Leerdoelengenerator-main/src/services/gemini.ts
+++ b/Leerdoelengenerator-main/src/services/gemini.ts
@@ -39,7 +39,10 @@ if (!API_KEY) {
 
 const MODEL_NAME = "gemini-1.5-flash"; // snel en goedkoop; desgewenst: "gemini-1.5-pro"
 
-const genAI = new GoogleGenerativeAI(API_KEY);
+let genAI: GoogleGenerativeAI | null = null;
+if (API_KEY) {
+  genAI = new GoogleGenerativeAI(API_KEY);
+}
 
 /**
  * Vocabulaire/termunen die elders in de app worden gebruikt.
@@ -121,6 +124,7 @@ function buildPrompt(ctx: LearningObjectiveContext, kd?: KDContext): string {
 
 /** Snelle check of de Gemini API bruikbaar is (key + simpele call). */
 export async function checkGeminiAvailable(): Promise<boolean> {
+  if (!genAI) return false;
   try {
     const model = genAI.getGenerativeModel({ model: MODEL_NAME });
     const res = await model.generateContent({
@@ -142,6 +146,9 @@ export async function generateAIReadyObjective(
   ctx: LearningObjectiveContext,
   kd?: KDContext
 ): Promise<GeminiResponse> {
+  if (!genAI) {
+    return Promise.reject(new Error("Gemini API key ontbreekt."));
+  }
   const model = genAI.getGenerativeModel({ model: MODEL_NAME });
 
   const prompt = buildPrompt(ctx, kd);
@@ -211,4 +218,9 @@ export const Terms = {
   autonomieTerms,
   samenwerkTerms,
   reflectieTerms
+};
+
+export const geminiService = {
+  isAvailable: () => Boolean(genAI),
+  generateAIReadyObjective,
 };


### PR DESCRIPTION
## Summary
- Instantiate GoogleGenerativeAI only when a Gemini API key is provided.
- Expose a `geminiService` stub that reports unavailable and rejects generation without a key.
- Disable AI lane selection and adjust logging when Gemini is missing.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 17 errors including no-explicit-any and unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68a3396dc72c833092b1780678995ec7