### PR TITLE
feat: add hero introduction section

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { KDImport } from "./components/KDImport";
 import { SavedObjectives } from "./components/SavedObjectives";
 import { TemplateLibrary } from "./components/TemplateLibrary";
+import { Hero } from "./components/Hero";
 
 /** Paneel-knoppen werken weer via named exports zoals voorheen */
 import { QualityChecker } from "./components/QualityChecker";
@@ -640,7 +641,8 @@ function App() {
         </div>
       </header>
 
-      <div className="max-w-7xl mx-auto px-6 py-8">
+      <Hero />
+      <div id="form-start" className="max-w-7xl mx-auto px-6 py-8">
         {/* Progress Steps */}
         <div className="mb-8">
           <div className="flex items-center justify-center space-x-8">

--- a/Leerdoelengenerator-main/src/components/Hero.tsx
+++ b/Leerdoelengenerator-main/src/components/Hero.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export function Hero() {
+  const scrollToForm = () => {
+    document.getElementById("form-start")?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <section className="bg-white dark:bg-gray-900">
+      <div className="mx-auto max-w-prose px-6 py-16 text-center">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          Leerdoelengenerator
+        </h1>
+        <p className="mt-4 text-lg text-gray-700 dark:text-gray-300">
+          Genereer toetsbare leerdoelen in helder Nederlands, afgestemd op Npuls-richtlijnen (AI-bewuste toetsing, AI-geletterdheid)
+        </p>
+        <ul className="mt-6 mx-auto w-fit list-disc list-inside space-y-2 text-left text-gray-700 dark:text-gray-300">
+          <li>Conform Two-Lane approach</li>
+          <li>SMART en toetsbaar</li>
+          <li>Transparant over AI-gebruik</li>
+        </ul>
+        <button
+          onClick={scrollToForm}
+          className="mt-8 rounded-lg bg-gradient-to-r from-green-600 to-orange-500 px-6 py-3 font-medium text-white hover:from-green-700 hover:to-orange-600"
+        >
+          Aan de slag
+        </button>
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- introduce Hero component with Npuls-aligned intro and call-to-action
- render Hero above existing content and smooth-scroll to form

## Testing
- `npm run lint` *(fails: Unexpected any / unused vars in existing files)*
- `npx eslint src/components/Hero.tsx src/App.tsx` *(fails: Unexpected any in pre-existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a34537a3ec8330a9933414817685e9