### PR TITLE
feat: add objective form validation

### DIFF
--- a/Leerdoelengenerator-main/package.json
+++ b/Leerdoelengenerator-main/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -16,7 +17,8 @@
     "jspdf": "^2.5.1",
     "docx": "^8.5.0",
     "file-saver": "^2.0.5",
-    "@google/generative-ai": "^0.2.1"
+    "@google/generative-ai": "^0.2.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
@@ -33,6 +35,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/Leerdoelengenerator-main/src/components/ObjectiveForm.tsx
+++ b/Leerdoelengenerator-main/src/components/ObjectiveForm.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { objectiveSchema, ObjectiveInput } from '../lib/validation';
+
+interface ObjectiveFormProps {
+  onSubmit: (data: ObjectiveInput) => void;
+}
+
+type ObjectiveFormState = {
+  original: string;
+  sector: ObjectiveInput['sector'] | '';
+  level: string;
+  domain: string;
+  assessment: string;
+};
+
+type ObjectiveErrors = Partial<Record<keyof ObjectiveInput, string>>;
+
+const emptyForm: ObjectiveFormState = {
+  original: '',
+  sector: '',
+  level: '',
+  domain: '',
+  assessment: ''
+};
+
+export function ObjectiveForm({ onSubmit }: ObjectiveFormProps) {
+  const [formData, setFormData] = useState<ObjectiveFormState>(emptyForm);
+  const [errors, setErrors] = useState<ObjectiveErrors>({});
+
+  const handleChange = (field: keyof ObjectiveFormState, value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const result = objectiveSchema.safeParse(formData);
+    if (result.success) {
+      setErrors({});
+      onSubmit(result.data);
+    } else {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setErrors({
+        original: fieldErrors.original?.[0],
+        sector: fieldErrors.sector?.[0],
+        level: fieldErrors.level?.[0],
+        domain: fieldErrors.domain?.[0],
+        assessment: fieldErrors.assessment?.[0]
+      });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="original" className="block text-sm font-medium text-gray-700">Oorspronkelijk leerdoel</label>
+        <textarea
+          id="original"
+          value={formData.original}
+          onChange={e => handleChange('original', e.target.value)}
+          placeholder="Bijv. De student kan een zakelijke e-mail schrijven."
+          aria-describedby="original-help"
+          className="w-full h-24 px-4 py-3 border border-gray-300 rounded-lg"
+        />
+        <small id="original-help" className="text-gray-500">Formuleer het huidige leerdoel in één zin.</small>
+        {errors.original && <p className="text-red-600 text-sm">{errors.original}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="sector" className="block text-sm font-medium text-gray-700">Onderwijssector (mbo/hbo/wo)</label>
+        <select
+          id="sector"
+          value={formData.sector}
+          onChange={e => handleChange('sector', e.target.value)}
+          aria-describedby="sector-help"
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+        >
+          <option value="">Kies sector</option>
+          <option value="mbo">mbo</option>
+          <option value="hbo">hbo</option>
+          <option value="wo">wo</option>
+        </select>
+        <small id="sector-help" className="text-gray-500">Kies de onderwijssector.</small>
+        {errors.sector && <p className="text-red-600 text-sm">{errors.sector}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="level" className="block text-sm font-medium text-gray-700">Niveau (mbo 2/3/4…)</label>
+        <input
+          id="level"
+          type="text"
+          value={formData.level}
+          onChange={e => handleChange('level', e.target.value)}
+          placeholder="Bijv. 3"
+          aria-describedby="level-help"
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+        />
+        <small id="level-help" className="text-gray-500">Bij mbo alleen niveau 2, 3 of 4.</small>
+        {errors.level && <p className="text-red-600 text-sm">{errors.level}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="domain" className="block text-sm font-medium text-gray-700">Domein/opleiding</label>
+        <input
+          id="domain"
+          type="text"
+          value={formData.domain}
+          onChange={e => handleChange('domain', e.target.value)}
+          placeholder="Bijv. Marketing"
+          aria-describedby="domain-help"
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+        />
+        <small id="domain-help" className="text-gray-500">Noem het domein of de opleiding.</small>
+        {errors.domain && <p className="text-red-600 text-sm">{errors.domain}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="assessment" className="block text-sm font-medium text-gray-700">Beoogde toetsing (baan 1/baan 2)</label>
+        <input
+          id="assessment"
+          type="text"
+          value={formData.assessment}
+          onChange={e => handleChange('assessment', e.target.value)}
+          placeholder="Bijv. portfolio of examen"
+          aria-describedby="assessment-help"
+          className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+        />
+        <small id="assessment-help" className="text-gray-500">Beschrijf hoe het doel getoetst wordt.</small>
+        {errors.assessment && <p className="text-red-600 text-sm">{errors.assessment}</p>}
+      </div>
+
+      <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">Versturen</button>
+    </form>
+  );
+}

--- a/Leerdoelengenerator-main/src/lib/validation.test.ts
+++ b/Leerdoelengenerator-main/src/lib/validation.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { objectiveSchema } from './validation';
+
+describe('objectiveSchema', () => {
+  it('valideert correcte data', () => {
+    const result = objectiveSchema.safeParse({
+      original: 'Doel',
+      sector: 'mbo',
+      level: '3',
+      domain: 'ICT',
+      assessment: 'Exam'
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('toont fouten bij ontbrekende velden', () => {
+    const result = objectiveSchema.safeParse({
+      original: '',
+      sector: '',
+      level: '',
+      domain: '',
+      assessment: ''
+    });
+    expect(result.success).toBe(false);
+    const errors = result.error.flatten().fieldErrors;
+    expect(errors.original?.[0]).toBe('Vul het leerdoel in.');
+    expect(errors.sector?.[0]).toBe('Kies mbo, hbo of wo.');
+    expect(errors.level?.[0]).toBe('Vul het niveau in.');
+    expect(errors.domain?.[0]).toBe('Vul het domein in.');
+    expect(errors.assessment?.[0]).toBe('Vul de toetsing in.');
+  });
+
+  it('valideert onderwijssector', () => {
+    const result = objectiveSchema.safeParse({
+      original: 'Doel',
+      sector: 'vmbo',
+      level: '3',
+      domain: 'ICT',
+      assessment: 'Exam'
+    });
+    expect(result.success).toBe(false);
+    expect(result.error.flatten().fieldErrors.sector?.[0]).toBe('Kies mbo, hbo of wo.');
+  });
+
+  it('controleert mbo niveau', () => {
+    const result = objectiveSchema.safeParse({
+      original: 'Doel',
+      sector: 'mbo',
+      level: '5',
+      domain: 'ICT',
+      assessment: 'Exam'
+    });
+    expect(result.success).toBe(false);
+    expect(result.error.flatten().fieldErrors.level?.[0]).toBe('Kies niveau 2, 3 of 4.');
+  });
+
+  it('accepteert niveaus buiten mbo', () => {
+    const result = objectiveSchema.safeParse({
+      original: 'Doel',
+      sector: 'hbo',
+      level: 'Bachelor',
+      domain: 'ICT',
+      assessment: 'Exam'
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/Leerdoelengenerator-main/src/lib/validation.ts
+++ b/Leerdoelengenerator-main/src/lib/validation.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const objectiveSchema = z.object({
+  original: z.string().min(1, 'Vul het leerdoel in.'),
+  sector: z.enum(['mbo', 'hbo', 'wo'], {
+    errorMap: () => ({ message: 'Kies mbo, hbo of wo.' })
+  }),
+  level: z.string().min(1, 'Vul het niveau in.'),
+  domain: z.string().min(1, 'Vul het domein in.'),
+  assessment: z.string().min(1, 'Vul de toetsing in.')
+}).refine(
+  data => data.sector !== 'mbo' || ['2', '3', '4'].includes(data.level),
+  {
+    message: 'Kies niveau 2, 3 of 4.',
+    path: ['level']
+  }
+);
+
+export type ObjectiveInput = z.infer<typeof objectiveSchema>;


### PR DESCRIPTION
## Summary
- add accessible ObjectiveForm component with placeholders and Dutch help text
- introduce zod schema enforcing sector and level rules with tests
- configure vitest and zod dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3454ddd2c83308210eca6113bdf47