### PR TITLE
feat: add voorbeeldcases panel

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { KDImport } from "./components/KDImport";
 import { SavedObjectives } from "./components/SavedObjectives";
 import { TemplateLibrary } from "./components/TemplateLibrary";
+import { ExamplesPanel } from "./components/ExamplesPanel";
 
 /** Paneel-knoppen werken weer via named exports zoals voorheen */
 import { QualityChecker } from "./components/QualityChecker";
@@ -220,6 +221,12 @@ function App() {
         "De student kan een marktanalyse maken waarbij AI-tools helpen met data verzamelen, de AI-resultaten controleren op juistheid, en zelf conclusies trekken voor het product.",
     },
   ];
+
+  const handleExampleSelect = (example: LearningObjective) => {
+    setFormData(example);
+    setOutput(null);
+    setCurrentStep(1);
+  };
 
   const isFormDataComplete = () =>
     formData.original.trim() !== "" &&
@@ -676,7 +683,8 @@ function App() {
 
         {/* Step 1: Input Form */}
         {currentStep === 1 && (
-          <div className="grid lg:grid-cols-3 gap-8">
+          <div className="grid lg:grid-cols-4 gap-8">
+            <ExamplesPanel onSelect={handleExampleSelect} />
             <div className="lg:col-span-2">
               <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
                 <h2 className="text-xl font-semibold text-gray-900 mb-6 flex items-center">

--- a/Leerdoelengenerator-main/src/components/ExamplesPanel.tsx
+++ b/Leerdoelengenerator-main/src/components/ExamplesPanel.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import { Lightbulb, ChevronDown } from "lucide-react";
+
+interface Example {
+  label: string;
+  data: {
+    original: string;
+    context: {
+      education: string;
+      level: string;
+      domain: string;
+      assessment: string;
+    };
+  };
+}
+
+interface ExamplesPanelProps {
+  onSelect: (data: Example["data"]) => void;
+}
+
+export function ExamplesPanel({ onSelect }: ExamplesPanelProps) {
+  const [open, setOpen] = useState(false);
+
+  const examples: Example[] = [
+    {
+      label: "mbo-zorg",
+      data: {
+        original: "De student kan een zorgplan opstellen voor een patiënt met diabetes.",
+        context: {
+          education: "MBO",
+          level: "Niveau 4",
+          domain: "Zorg",
+          assessment: "Portfolio",
+        },
+      },
+    },
+    {
+      label: "mbo-sport",
+      data: {
+        original: "De student kan een trainingsschema ontwerpen voor een beginnende hardloper.",
+        context: {
+          education: "MBO",
+          level: "Niveau 3",
+          domain: "Sport",
+          assessment: "Praktijkopdracht",
+        },
+      },
+    },
+    {
+      label: "hbo-ict",
+      data: {
+        original: "De student kan een eenvoudige webapplicatie ontwikkelen met React.",
+        context: {
+          education: "HBO",
+          level: "Bachelor",
+          domain: "ICT",
+          assessment: "Project",
+        },
+      },
+    },
+  ];
+
+  return (
+    <div className="md:w-64">
+      {/* Mobile accordion */}
+      <div className="md:hidden mb-4">
+        <button
+          onClick={() => setOpen(!open)}
+          className="w-full flex items-center justify-between bg-green-600 text-white px-4 py-2 rounded-lg"
+        >
+          <span>Voorbeeldcases</span>
+          <ChevronDown
+            className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
+          />
+        </button>
+        {open && (
+          <div className="mt-2 space-y-2">
+            {examples.map((ex) => (
+              <button
+                key={ex.label}
+                onClick={() => onSelect(ex.data)}
+                className="w-full text-left px-4 py-2 bg-green-50 border border-green-200 rounded-lg hover:bg-green-100"
+              >
+                {ex.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Desktop sidebar */}
+      <div className="hidden md:block bg-green-50 border border-green-200 rounded-xl p-4">
+        <h3 className="font-semibold text-green-800 mb-3 flex items-center">
+          <Lightbulb className="w-5 h-5 mr-2" />
+          Voorbeeldcases
+        </h3>
+        <div className="space-y-2">
+          {examples.map((ex) => (
+            <button
+              key={ex.label}
+              onClick={() => onSelect(ex.data)}
+              className="w-full text-left px-4 py-2 bg-white border border-green-200 rounded-lg hover:bg-green-100"
+            >
+              {ex.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ExamplePanel with three example cases to autofill the learning goal form
- integrate panel on step 1 and mobile accordion behaviour

## Testing
- `npm run lint` *(fails: BookOpen is defined but never used, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a345c618c48330af8d655ff42aa3f6