### PR TITLE
Add transparantie & verantwoording page

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -1168,6 +1168,10 @@ function App() {
         )}
       </div>
 
+      <footer className="mt-12 text-center text-sm text-gray-600">
+        <a href="/over" className="hover:underline">Transparantie & Verantwoording</a>
+      </footer>
+
       {/* Modals */}
       {showKDImport && <KDImport onKDImported={handleKDImported} onClose={() => setShowKDImport(false)} />}
       {showSavedObjectives && <SavedObjectives onLoadObjective={loadObjective} onClose={() => setShowSavedObjectives(false)} />}

--- a/Leerdoelengenerator-main/src/main.tsx
+++ b/Leerdoelengenerator-main/src/main.tsx
@@ -1,10 +1,18 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import About from './pages/About.tsx';
 import './index.css';
 
-createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root')!;
+
+function Router() {
+  const path = window.location.pathname;
+  return path === '/over' ? <About /> : <App />;
+}
+
+createRoot(rootElement).render(
   <StrictMode>
-    <App />
+    <Router />
   </StrictMode>
 );

--- a/Leerdoelengenerator-main/src/pages/About.tsx
+++ b/Leerdoelengenerator-main/src/pages/About.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+export default function About() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl font-bold">Transparantie &amp; Verantwoording</h1>
+
+      <section>
+        <h2 className="text-xl font-semibold mt-4">Hoe werkt de generator</h2>
+        <p className="mt-2 text-gray-700">
+          Onze tool gebruikt een groot taalmodel om aangeleverde leeruitkomsten te herschrijven.
+          De ruwe output gaat daarna door een set regels en controles zodat formuleringen duidelijk,
+          haalbaar en passend bij het onderwijsniveau worden.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mt-4">Raamwerken en bronnen</h2>
+        <p className="mt-2 text-gray-700">
+          We baseren ons op Npuls Visie en Handreikingen, AI-GO en het Referentiekader 2.0 om
+          verantwoorde keuzes te maken rond transparantie, inclusie en kwaliteitsbewaking.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mt-4">Privacy &amp; ontwerp</h2>
+        <p className="mt-2 text-gray-700">
+          De generator verwerkt geen persoonsgegevens. Alles wat je invoert blijft lokaal in je browser
+          en wordt niet opgeslagen op onze servers. Met privacy-by-design beperken we gegevens tot het
+          strikt noodzakelijke en bouwen we functies zodat delen of exporteren alleen gebeurt op jouw
+          initiatief.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add Transparantie & Verantwoording page detailing generator, frameworks and privacy approach
- simple router to serve /over and link in footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 17 errors, 1 warning)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a345b1bf6883308a23f6a71ebe8508