### PR TITLE
Add privacy banner under form

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { KDImport } from "./components/KDImport";
 import { SavedObjectives } from "./components/SavedObjectives";
 import { TemplateLibrary } from "./components/TemplateLibrary";
+import { PrivacyNote } from "./components/PrivacyNote";
 
 /** Paneel-knoppen werken weer via named exports zoals voorheen */
 import { QualityChecker } from "./components/QualityChecker";
@@ -812,6 +813,7 @@ function App() {
                     Omzetten naar AI-ready onderwijs
                     <ChevronRight className="w-5 h-5 ml-2" />
                   </button>
+                  <PrivacyNote />
                 </div>
               </div>
             </div>

--- a/Leerdoelengenerator-main/src/components/PrivacyNote.tsx
+++ b/Leerdoelengenerator-main/src/components/PrivacyNote.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function PrivacyNote() {
+  return (
+    <div className="mt-4 p-3 bg-slate-50 border border-slate-200 rounded text-xs text-slate-600">
+      We slaan geen persoonsgegevens op. Resultaten blijven in je browser.{" "}
+      <a href="/over" className="underline">Meer info</a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add compact privacy note component to clarify no personal data storage and link to more info
- display privacy banner below the main form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 17 errors - existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a345ebb0b08330b95d093981fd60e3