### PR TITLE
Improve LLM error handling and result UI

### DIFF
--- a/Leerdoelengenerator-main/src/components/ResultCard.tsx
+++ b/Leerdoelengenerator-main/src/components/ResultCard.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { callLLM, LLMResult } from '../services/llm';
+
+export default function ResultCard() {
+  const [original, setOriginal] = useState('');
+  const [education, setEducation] = useState('');
+  const [level, setLevel] = useState('');
+  const [domain, setDomain] = useState('');
+  const [result, setResult] = useState<LLMResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setResult(null);
+    if (!original.trim() || !education.trim() || !level.trim() || !domain.trim()) {
+      setError('Vul alle verplichte velden in.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await callLLM({ original, education, level, domain });
+      setResult(res);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Er ging iets mis.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 border rounded-lg bg-white">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <textarea
+          value={original}
+          onChange={(e) => setOriginal(e.target.value)}
+          placeholder="Origineel leerdoel"
+          className="w-full border p-2 rounded"
+        />
+        <input
+          value={education}
+          onChange={(e) => setEducation(e.target.value)}
+          placeholder="Onderwijs"
+          className="w-full border p-2 rounded"
+        />
+        <input
+          value={level}
+          onChange={(e) => setLevel(e.target.value)}
+          placeholder="Niveau"
+          className="w-full border p-2 rounded"
+        />
+        <input
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          placeholder="Domein"
+          className="w-full border p-2 rounded"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          {loading ? 'Bezig...' : 'Genereer'}
+        </button>
+      </form>
+
+      {error && <p className="mt-4 text-red-700">{error}</p>}
+
+      {result && (
+        <div className="mt-4 space-y-2">
+          {result.autoFixed && (
+            <div className="p-2 bg-yellow-100 border border-yellow-300 text-yellow-800 rounded">
+              Automatisch hersteld
+            </div>
+          )}
+          <h3 className="font-semibold text-green-700">{result.data.newObjective}</h3>
+          <p className="text-gray-700">{result.data.rationale}</p>
+          {result.data.activities.length > 0 && (
+            <div>
+              <p className="font-medium">Activiteiten:</p>
+              <ul className="list-disc list-inside">
+                {result.data.activities.map((a, i) => (
+                  <li key={i}>{a}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {result.data.assessments.length > 0 && (
+            <div>
+              <p className="font-medium">Toetsing:</p>
+              <ul className="list-disc list-inside">
+                {result.data.assessments.map((a, i) => (
+                  <li key={i}>{a}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/services/llm.ts
+++ b/Leerdoelengenerator-main/src/services/llm.ts
@@ -1,0 +1,88 @@
+import type { GeminiResponse } from './gemini';
+
+export interface LLMRequest {
+  original: string;
+  education: string;
+  level: string;
+  domain: string;
+  assessment?: string;
+}
+
+export interface LLMResult {
+  data: GeminiResponse;
+  autoFixed: boolean;
+}
+
+export function tryFixJson(input: string): Record<string, unknown> | null {
+  const cleaned = input
+    .replace(/```json\s*|```/gi, '')
+    .trim();
+
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    const start = cleaned.indexOf('{');
+    const end = cleaned.lastIndexOf('}');
+    if (start !== -1 && end !== -1) {
+      try {
+        return JSON.parse(cleaned.slice(start, end + 1));
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+const TIMEOUT_MS = 20000;
+
+export async function callLLM(payload: LLMRequest, timeoutMs = TIMEOUT_MS): Promise<LLMResult> {
+  if (!payload.original.trim() || !payload.education.trim() || !payload.level.trim() || !payload.domain.trim()) {
+    throw new Error('Vul alle verplichte velden in.');
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch('/api/llm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    const text = await res.text();
+    clearTimeout(timeout);
+
+    let autoFixed = false;
+    let json: unknown;
+
+    try {
+      json = JSON.parse(text);
+    } catch {
+      const fixed = tryFixJson(text);
+      if (fixed) {
+        json = fixed;
+        autoFixed = true;
+      } else {
+        throw new Error('Kon antwoord van AI niet verwerken.');
+      }
+    }
+
+    const obj = json as Record<string, unknown>;
+    const data: GeminiResponse = {
+      newObjective: String(obj.newObjective ?? ''),
+      rationale: String(obj.rationale ?? ''),
+      activities: Array.isArray(obj.activities) ? (obj.activities as unknown[]).map(String) : [],
+      assessments: Array.isArray(obj.assessments) ? (obj.assessments as unknown[]).map(String) : [],
+    };
+
+    return { data, autoFixed };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error('De aanvraag duurde te lang. Probeer korter origineel leerdoel.');
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}


### PR DESCRIPTION
## Summary
- Add LLM service with timeout handling, JSON recovery, and field validation
- Introduce ResultCard component showing auto-fix banner and blocking empty submissions

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a345f9d1908330b5d76a7dbd049dc0