### PR TITLE
test: add coverage for formatting, validation, and JSON parsing

### DIFF
--- a/Leerdoelengenerator-main/package.json
+++ b/Leerdoelengenerator-main/package.json
@@ -7,22 +7,24 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.2.1",
+    "docx": "^8.5.0",
+    "file-saver": "^2.0.5",
+    "jspdf": "^2.5.1",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "jspdf": "^2.5.1",
-    "docx": "^8.5.0",
-    "file-saver": "^2.0.5",
-    "@google/generative-ai": "^0.2.1"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@types/file-saver": "^2.0.7",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
-    "@types/file-saver": "^2.0.7",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.18",
     "eslint": "^9.9.1",
@@ -33,6 +35,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/Leerdoelengenerator-main/src/lib/format.test.ts
+++ b/Leerdoelengenerator-main/src/lib/format.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { enforceDutchAndSMART } from './format';
+
+describe('enforceDutchAndSMART', () => {
+  it('adds prefix when missing', () => {
+    const res = enforceDutchAndSMART('Schrijft een verslag');
+    expect(res).toBe('De student kan schrijft een verslag.');
+  });
+
+  it('keeps prefix if present', () => {
+    const res = enforceDutchAndSMART('De student kan plannen.');
+    expect(res).toBe('De student kan plannen.');
+  });
+
+  it('trims whitespace and adds period', () => {
+    const res = enforceDutchAndSMART('  plannen een project  ');
+    expect(res).toBe('De student kan plannen een project.');
+  });
+
+  it('lowercases first letter after prefix', () => {
+    const res = enforceDutchAndSMART('Ontwerpen een website');
+    expect(res).toBe('De student kan ontwerpen een website.');
+  });
+});

--- a/Leerdoelengenerator-main/src/lib/format.ts
+++ b/Leerdoelengenerator-main/src/lib/format.ts
@@ -1,0 +1,11 @@
+export function enforceDutchAndSMART(input: string): string {
+  let result = input.trim();
+  if (!result.toLowerCase().startsWith("de student kan")) {
+    const lower = result.charAt(0).toLowerCase() + result.slice(1);
+    result = `De student kan ${lower}`;
+  }
+  if (!result.endsWith('.')) {
+    result = result + '.';
+  }
+  return result;
+}

--- a/Leerdoelengenerator-main/src/lib/validation.test.ts
+++ b/Leerdoelengenerator-main/src/lib/validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { geminiResponseSchema } from './validation';
+
+describe('geminiResponseSchema', () => {
+  it('validates a correct object', () => {
+    const data = {
+      newObjective: 'Leerdoel',
+      rationale: 'Omdat het moet',
+      activities: ['activiteit'],
+      assessments: ['toets']
+    };
+    const parsed = geminiResponseSchema.parse(data);
+    expect(parsed).toEqual(data);
+  });
+
+  it('requires newObjective', () => {
+    const result = geminiResponseSchema.safeParse({
+      rationale: 'Reden',
+      activities: ['activiteit']
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('requires non-empty activities', () => {
+    const result = geminiResponseSchema.safeParse({
+      newObjective: 'Doel',
+      rationale: 'Reden',
+      activities: []
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults assessments to empty array', () => {
+    const parsed = geminiResponseSchema.parse({
+      newObjective: 'Doel',
+      rationale: 'Reden',
+      activities: ['activiteit']
+    });
+    expect(parsed.assessments).toEqual([]);
+  });
+});

--- a/Leerdoelengenerator-main/src/lib/validation.ts
+++ b/Leerdoelengenerator-main/src/lib/validation.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const geminiResponseSchema = z.object({
+  newObjective: z.string().min(1),
+  rationale: z.string().min(1),
+  activities: z.array(z.string()).min(1),
+  assessments: z.array(z.string()).default([])
+});
+
+export type GeminiResponse = z.infer<typeof geminiResponseSchema>;

--- a/Leerdoelengenerator-main/src/services/llm.test.ts
+++ b/Leerdoelengenerator-main/src/services/llm.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { parseLLMJson } from './llm';
+
+describe('parseLLMJson', () => {
+  it('parses plain JSON', () => {
+    const result = parseLLMJson('{"a":1}');
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('parses JSON code block', () => {
+    const input = "```json\n{\"b\":2}\n```";
+    const result = parseLLMJson(input);
+    expect(result).toEqual({ b: 2 });
+  });
+
+  it('parses generic code block', () => {
+    const input = "```\n{\"c\":3}\n```";
+    const result = parseLLMJson(input);
+    expect(result).toEqual({ c: 3 });
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseLLMJson('not json')).toThrow();
+  });
+});

--- a/Leerdoelengenerator-main/src/services/llm.ts
+++ b/Leerdoelengenerator-main/src/services/llm.ts
@@ -1,0 +1,8 @@
+export function parseLLMJson(raw: string): any {
+  const cleaned = raw
+    .replace(/^```json\s*/i, '')
+    .replace(/^```\s*/i, '')
+    .replace(/```$/i, '')
+    .trim();
+  return JSON.parse(cleaned || raw);
+}


### PR DESCRIPTION
## Summary
- add `enforceDutchAndSMART` helper and tests
- validate Gemini response structure with Zod schema
- ensure JSON parser handles code-block responses

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3460462bc83308c9d116fc2ca1a72