### PR TITLE
Use dropdowns for sector and level

### DIFF
--- a/Leerdoelengenerator-main/src/components/ObjectiveForm.tsx
+++ b/Leerdoelengenerator-main/src/components/ObjectiveForm.tsx
@@ -28,12 +28,22 @@ export function ObjectiveForm({ onSubmit }: ObjectiveFormProps) {
   const [errors, setErrors] = useState<ObjectiveErrors>({});
 
   const handleChange = (field: keyof ObjectiveFormState, value: string) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+    setFormData(prev => {
+      const next = { ...prev, [field]: value };
+      if (field === 'sector' && value !== 'mbo') {
+        next.level = '';
+      }
+      return next;
+    });
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const result = objectiveSchema.safeParse(formData);
+    const dataToValidate = {
+      ...formData,
+      level: formData.sector === 'mbo' ? formData.level : undefined
+    };
+    const result = objectiveSchema.safeParse(dataToValidate);
     if (result.success) {
       setErrors({});
       onSubmit(result.data);
@@ -83,32 +93,44 @@ export function ObjectiveForm({ onSubmit }: ObjectiveFormProps) {
         {errors.sector && <p className="text-red-600 text-sm">{errors.sector}</p>}
       </div>
 
-      <div>
-        <label htmlFor="level" className="block text-sm font-medium text-gray-700">Niveau (mbo 2/3/4…)</label>
-        <input
-          id="level"
-          type="text"
-          value={formData.level}
-          onChange={e => handleChange('level', e.target.value)}
-          placeholder="Bijv. 3"
-          aria-describedby="level-help"
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg"
-        />
-        <small id="level-help" className="text-gray-500">Bij mbo alleen niveau 2, 3 of 4.</small>
-        {errors.level && <p className="text-red-600 text-sm">{errors.level}</p>}
-      </div>
+      {formData.sector === 'mbo' && (
+        <div>
+          <label htmlFor="level" className="block text-sm font-medium text-gray-700">Niveau (mbo 2/3/4…)</label>
+          <select
+            id="level"
+            value={formData.level}
+            onChange={e => handleChange('level', e.target.value)}
+            aria-describedby="level-help"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+          >
+            <option value="">Kies niveau</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+          </select>
+          <small id="level-help" className="text-gray-500">Bij mbo alleen niveau 2, 3 of 4.</small>
+          {errors.level && <p className="text-red-600 text-sm">{errors.level}</p>}
+        </div>
+      )}
 
       <div>
         <label htmlFor="domain" className="block text-sm font-medium text-gray-700">Domein/opleiding</label>
         <input
           id="domain"
           type="text"
+          list="domain-options"
           value={formData.domain}
           onChange={e => handleChange('domain', e.target.value)}
           placeholder="Bijv. Marketing"
           aria-describedby="domain-help"
           className="w-full px-4 py-3 border border-gray-300 rounded-lg"
         />
+        <datalist id="domain-options">
+          <option value="Economie" />
+          <option value="Zorg" />
+          <option value="Sport & Bewegen" />
+          <option value="Techniek" />
+        </datalist>
         <small id="domain-help" className="text-gray-500">Noem het domein of de opleiding.</small>
         {errors.domain && <p className="text-red-600 text-sm">{errors.domain}</p>}
       </div>

--- a/Leerdoelengenerator-main/src/lib/validation.test.ts
+++ b/Leerdoelengenerator-main/src/lib/validation.test.ts
@@ -25,9 +25,9 @@ describe('objectiveSchema', () => {
     const errors = result.error.flatten().fieldErrors;
     expect(errors.original?.[0]).toBe('Vul het leerdoel in.');
     expect(errors.sector?.[0]).toBe('Kies mbo, hbo of wo.');
-    expect(errors.level?.[0]).toBe('Vul het niveau in.');
     expect(errors.domain?.[0]).toBe('Vul het domein in.');
     expect(errors.assessment?.[0]).toBe('Vul de toetsing in.');
+    expect(errors.level).toBeUndefined();
   });
 
   it('valideert onderwijssector', () => {
@@ -54,11 +54,22 @@ describe('objectiveSchema', () => {
     expect(result.error.flatten().fieldErrors.level?.[0]).toBe('Kies niveau 2, 3 of 4.');
   });
 
-  it('accepteert niveaus buiten mbo', () => {
+  it('vereist niveau voor mbo', () => {
+    const result = objectiveSchema.safeParse({
+      original: 'Doel',
+      sector: 'mbo',
+      level: '',
+      domain: 'ICT',
+      assessment: 'Exam'
+    });
+    expect(result.success).toBe(false);
+    expect(result.error.flatten().fieldErrors.level?.[0]).toBe('Vul het niveau in.');
+  });
+
+  it('accepteert hbo zonder niveau', () => {
     const result = objectiveSchema.safeParse({
       original: 'Doel',
       sector: 'hbo',
-      level: 'Bachelor',
       domain: 'ICT',
       assessment: 'Exam'
     });

--- a/Leerdoelengenerator-main/src/lib/validation.ts
+++ b/Leerdoelengenerator-main/src/lib/validation.ts
@@ -5,15 +5,25 @@ export const objectiveSchema = z.object({
   sector: z.enum(['mbo', 'hbo', 'wo'], {
     errorMap: () => ({ message: 'Kies mbo, hbo of wo.' })
   }),
-  level: z.string().min(1, 'Vul het niveau in.'),
+  level: z.string().optional(),
   domain: z.string().min(1, 'Vul het domein in.'),
   assessment: z.string().min(1, 'Vul de toetsing in.')
-}).refine(
-  data => data.sector !== 'mbo' || ['2', '3', '4'].includes(data.level),
-  {
-    message: 'Kies niveau 2, 3 of 4.',
-    path: ['level']
+}).superRefine((data, ctx) => {
+  if (data.sector === 'mbo') {
+    if (!data.level) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Vul het niveau in.',
+        path: ['level']
+      });
+    } else if (!['2', '3', '4'].includes(data.level)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Kies niveau 2, 3 of 4.',
+        path: ['level']
+      });
+    }
   }
-);
+});
 
 export type ObjectiveInput = z.infer<typeof objectiveSchema>;


### PR DESCRIPTION
## Summary
- Show "Onderwijssector" as a select menu and reset level when sector changes
- Render "Niveau" as a dropdown only for mbo with options 2/3/4
- Add domain suggestions and relax validation so level is only required for mbo

## Testing
- `npm run lint` *(fails: eslint: not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a356b736208330a398cf91fbd95c8c