### PR TITLE
Add example cases sidebar for quick form prefilling

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -10,6 +10,7 @@ import { KDImport } from "./components/KDImport";
 import { SavedObjectives } from "./components/SavedObjectives";
 import { TemplateLibrary } from "./components/TemplateLibrary";
 import { Hero } from "./components/Hero";
+import ExamplesPanel from "./components/ExamplesPanel";
 
 /** Paneel-knoppen werken weer via named exports zoals voorheen */
 import { QualityChecker } from "./components/QualityChecker";
@@ -141,6 +142,10 @@ function App() {
   const [showQualityChecker, setShowQualityChecker] = useState(false);
   const [showEducationGuidance, setShowEducationGuidance] = useState(false);
   const [generationSource, setGenerationSource] = useState<GenerationSource>(null); // NIEUW: bron van de laatste generatie
+
+  const handleExampleSelect = (example: LearningObjective) => {
+    setFormData(example);
+  };
 
   /* ---------- Hydrate bij laden (eerst URL, anders localStorage) ---------- */
   useEffect(() => {
@@ -696,7 +701,10 @@ function App() {
 
         {/* Step 1: Input Form */}
         {currentStep === 1 && (
-          <div className="grid lg:grid-cols-3 gap-8">
+          <div className="grid lg:grid-cols-4 gap-8">
+            <div className="lg:col-span-1">
+              <ExamplesPanel onSelectExample={handleExampleSelect} />
+            </div>
             <div className="lg:col-span-2">
               <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
                 <h2 className="text-xl font-semibold text-gray-900 mb-6 flex items-center">
@@ -813,7 +821,7 @@ function App() {
             </div>
 
             {/* Examples Sidebar */}
-            <div className="space-y-6">
+            <div className="lg:col-span-1 space-y-6">
               <div className="bg-green-50 border border-green-200 rounded-xl p-6">
                 <h3 className="font-semibold text-green-800 mb-3 flex items-center">
                   <Lightbulb className="w-5 h-5 mr-2" />

--- a/Leerdoelengenerator-main/src/components/ExamplesPanel.tsx
+++ b/Leerdoelengenerator-main/src/components/ExamplesPanel.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from "react";
+
+interface Example {
+  id: string;
+  label: string;
+  data: {
+    original: string;
+    context: {
+      education: string;
+      level: string;
+      domain: string;
+      assessment: string;
+    };
+  };
+}
+
+interface ExamplesPanelProps {
+  onSelectExample: (data: Example["data"]) => void;
+}
+
+const examples: Example[] = [
+  {
+    id: "mbo-zorg",
+    label: "mbo-zorg",
+    data: {
+      original: "De student kan basiszorg verlenen aan een cliënt.",
+      context: {
+        education: "MBO",
+        level: "Niveau 4",
+        domain: "Zorg",
+        assessment: "Praktijkexamen",
+      },
+    },
+  },
+  {
+    id: "mbo-sport",
+    label: "mbo-sport",
+    data: {
+      original: "De student kan een trainingsschema opstellen voor een beginnende sporter.",
+      context: {
+        education: "MBO",
+        level: "Niveau 3",
+        domain: "Sport & Bewegen",
+        assessment: "Portfolio",
+      },
+    },
+  },
+  {
+    id: "hbo-ict",
+    label: "hbo-ict",
+    data: {
+      original: "De student kan een eenvoudige webapplicatie ontwikkelen en testen.",
+      context: {
+        education: "HBO",
+        level: "Bachelor",
+        domain: "ICT",
+        assessment: "Projectpresentatie",
+      },
+    },
+  },
+];
+
+export default function ExamplesPanel({ onSelectExample }: ExamplesPanelProps) {
+  const [open, setOpen] = useState(false);
+
+  const Buttons = () => (
+    <div className="mt-4 space-y-2">
+      {examples.map((ex) => (
+        <button
+          key={ex.id}
+          onClick={() => onSelectExample(ex.data)}
+          className="w-full text-left px-4 py-2 bg-green-50 hover:bg-green-100 border border-green-200 rounded-lg text-sm"
+        >
+          {ex.label}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <aside className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 md:p-6">
+      {/* Mobile accordion */}
+      <div className="md:hidden">
+        <button
+          onClick={() => setOpen(!open)}
+          className="w-full flex justify-between items-center font-semibold text-gray-800"
+        >
+          Voorbeeldcases
+          <span>{open ? "-" : "+"}</span>
+        </button>
+        {open && <Buttons />}
+      </div>
+
+      {/* Desktop sidebar */}
+      <div className="hidden md:block">
+        <h3 className="font-semibold text-gray-800">Voorbeeldcases</h3>
+        <Buttons />
+      </div>
+    </aside>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add responsive `ExamplesPanel` with mbo-zorg, mbo-sport and hbo-ict presets
- integrate panel left of main form and wire selection to prefill fields

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a35c55f21883308ca0d7b55b19f3f8