### PR TITLE
Add privacy notice under form

### DIFF
--- a/Leerdoelengenerator-main/src/components/ObjectiveForm.tsx
+++ b/Leerdoelengenerator-main/src/components/ObjectiveForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { objectiveSchema, ObjectiveInput } from '../lib/validation';
+import PrivacyNote from './PrivacyNote';
 
 interface ObjectiveFormProps {
   onSubmit: (data: ObjectiveInput) => void;
@@ -60,8 +61,9 @@ export function ObjectiveForm({ onSubmit }: ObjectiveFormProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
         <label htmlFor="original" className="block text-sm font-medium text-gray-700">Oorspronkelijk leerdoel</label>
         <textarea
           id="original"
@@ -135,22 +137,24 @@ export function ObjectiveForm({ onSubmit }: ObjectiveFormProps) {
         {errors.domain && <p className="text-red-600 text-sm">{errors.domain}</p>}
       </div>
 
-      <div>
-        <label htmlFor="assessment" className="block text-sm font-medium text-gray-700">Beoogde toetsing (baan 1/baan 2)</label>
-        <input
-          id="assessment"
-          type="text"
-          value={formData.assessment}
-          onChange={e => handleChange('assessment', e.target.value)}
-          placeholder="Bijv. portfolio of examen"
-          aria-describedby="assessment-help"
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg"
-        />
-        <small id="assessment-help" className="text-gray-500">Beschrijf hoe het doel getoetst wordt.</small>
-        {errors.assessment && <p className="text-red-600 text-sm">{errors.assessment}</p>}
-      </div>
+        <div>
+          <label htmlFor="assessment" className="block text-sm font-medium text-gray-700">Beoogde toetsing (baan 1/baan 2)</label>
+          <input
+            id="assessment"
+            type="text"
+            value={formData.assessment}
+            onChange={e => handleChange('assessment', e.target.value)}
+            placeholder="Bijv. portfolio of examen"
+            aria-describedby="assessment-help"
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg"
+          />
+          <small id="assessment-help" className="text-gray-500">Beschrijf hoe het doel getoetst wordt.</small>
+          {errors.assessment && <p className="text-red-600 text-sm">{errors.assessment}</p>}
+        </div>
 
-      <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">Versturen</button>
-    </form>
+        <button type="submit" className="bg-green-600 text-white px-4 py-2 rounded">Versturen</button>
+      </form>
+      <PrivacyNote />
+    </>
   );
 }

--- a/Leerdoelengenerator-main/src/components/PrivacyNote.tsx
+++ b/Leerdoelengenerator-main/src/components/PrivacyNote.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+// Bron: Referentiekader 2.0 (zorgvuldigheid/transparantie)
+export default function PrivacyNote() {
+  return (
+    <p className="mt-4 text-xs text-gray-600 text-center">
+      We slaan geen persoonsgegevens op. Resultaten blijven in je browser.{' '}
+      <a href="/over" className="text-blue-600 underline">Meer info</a>
+    </p>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add compact privacy banner with link to About page
- show banner below objective form

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68a3621d04cc8330808ed56e65e3d6e9