### PR TITLE
feat: add robust error handling

### DIFF
--- a/Leerdoelengenerator-main/src/components/ResultCard.tsx
+++ b/Leerdoelengenerator-main/src/components/ResultCard.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import type { PostProcessedResponse } from '../lib/format';
+
+interface ResultCardProps {
+  result?: PostProcessedResponse;
+  error?: string;
+  onSave?: () => void;
+}
+
+/**
+ * Toont de gegenereerde leerdoelinformatie en eventuele foutmeldingen.
+ */
+export const ResultCard: React.FC<ResultCardProps> = ({ result, error, onSave }) => {
+  if (error) {
+    return (
+      <div className="p-4 bg-red-50 border border-red-200 rounded text-red-800">
+        {error}
+      </div>
+    );
+  }
+
+  if (!result) return null;
+
+  const autoFixed = result.warnings.includes('Automatisch hersteld');
+  const remainingWarnings = result.warnings.filter(w => w !== 'Automatisch hersteld');
+  const isIncomplete = !result.newObjective || !result.rationale;
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-4">
+      {autoFixed && (
+        <div className="mb-3 p-2 bg-yellow-50 border border-yellow-200 text-yellow-800 rounded">
+          Automatisch hersteld
+        </div>
+      )}
+
+      <h3 className="font-semibold text-gray-900 mb-2">AI-ready leerdoel</h3>
+      <p className="text-gray-700 mb-4">{result.newObjective}</p>
+
+      <h4 className="font-medium text-gray-900 mb-1">Rationale</h4>
+      <p className="text-gray-700 mb-4">{result.rationale}</p>
+
+      {remainingWarnings.length > 0 && (
+        <ul className="mb-4 p-2 bg-orange-50 border border-orange-200 rounded text-orange-800 text-sm list-disc list-inside">
+          {remainingWarnings.map((w, idx) => (
+            <li key={idx}>{w}</li>
+          ))}
+        </ul>
+      )}
+
+      {onSave && (
+        <button
+          onClick={onSave}
+          disabled={isIncomplete}
+          className="mt-2 bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          Opslaan
+        </button>
+      )}
+      {onSave && isIncomplete && (
+        <p className="text-sm text-red-600 mt-2">Vul alle velden in.</p>
+      )}
+    </div>
+  );
+};
+
+export default ResultCard;

--- a/Leerdoelengenerator-main/src/services/llm.ts
+++ b/Leerdoelengenerator-main/src/services/llm.ts
@@ -3,14 +3,81 @@ import { geminiService } from "./gemini";
 import { enforceDutchAndSMART, PostProcessedResponse } from "../lib/format";
 
 /**
+ * Probeer eenvoudige JSON-fouten te herstellen. Strip bijvoorbeeld
+ * codeblokken en losse komma's. Geeft een gerepareerde string terug of null.
+ */
+function tryFixJson(raw: string): string | null {
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {
+    try {
+      const cleaned = raw
+        .replace(/^```json\s*/i, "")
+        .replace(/^```\s*/i, "")
+        .replace(/```$/, "")
+        .replace(/,\s*}/g, "}")
+        .replace(/,\s*]/g, "]")
+        .trim();
+      JSON.parse(cleaned);
+      return cleaned;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error("TIMEOUT")), ms)
+    ),
+  ]);
+}
+
+/**
  * Wrapper rond het LLM dat de rauwe modelrespons normaliseert.
  */
 export async function generateNormalizedObjective(
   ctx: LearningObjectiveContext,
   kd?: KDContext
 ): Promise<PostProcessedResponse> {
-  const raw: GeminiResponse = await geminiService.generateAIReadyObjective(ctx, kd);
-  return enforceDutchAndSMART(raw, ctx.lane ?? "baan1");
+  let autoFixed = false;
+  let raw: GeminiResponse | string;
+  try {
+    raw = await withTimeout(
+      geminiService.generateAIReadyObjective(ctx, kd),
+      15000
+    );
+  } catch (err: any) {
+    if (err?.message === "TIMEOUT") {
+      throw new Error("Probeer korter origineel leerdoel");
+    }
+    throw err;
+  }
+
+  let data: GeminiResponse;
+  if (typeof raw === "string") {
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      const fixed = tryFixJson(raw);
+      if (!fixed) {
+        throw new Error("Model produceerde ongeldige JSON");
+      }
+      data = JSON.parse(fixed);
+      autoFixed = true;
+    }
+  } else {
+    data = raw;
+  }
+
+  const processed = enforceDutchAndSMART(data, ctx.lane ?? "baan1");
+  if (autoFixed) {
+    processed.warnings.unshift("Automatisch hersteld");
+  }
+  return processed;
 }
 
 export const llmService = { generateNormalizedObjective };


### PR DESCRIPTION
## Summary
- handle timeouts and malformed JSON in LLM service, including auto-fix warnings
- add ResultCard component with user-friendly Dutch error and warning banners

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a36456cd888330b7d0ed9469cf5364