### PR TITLE
feat: add export options to result card

### DIFF
--- a/Leerdoelengenerator-main/src/components/ResultCard.tsx
+++ b/Leerdoelengenerator-main/src/components/ResultCard.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { Copy, FileText, FileDown } from 'lucide-react';
+import { exportToDocx, exportToPdf, ExportMetadata, ExportSection } from '../lib/export';
+
+interface ResultCardProps {
+  metadata: ExportMetadata;
+  sections: ExportSection[];
+}
+
+export function ResultCard({ metadata, sections }: ResultCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text = [
+      metadata.title,
+      `Datum: ${metadata.date}`,
+      `Baan: ${metadata.baan}`,
+      `Sector/Niveau: ${metadata.sector} / ${metadata.niveau}`,
+      ...sections.flatMap((s) => [s.title, s.content]),
+    ].join('\n\n');
+
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDocx = () => exportToDocx(metadata, sections);
+  const handlePdf = () => exportToPdf(metadata, sections);
+
+  return (
+    <div className="relative bg-white rounded-lg shadow p-6 space-y-4">
+      <div className="absolute top-4 right-4 flex space-x-2">
+        <button
+          onClick={handleCopy}
+          className="p-2 bg-gray-100 hover:bg-gray-200 rounded transition-colors"
+          title="Kopieer alles"
+        >
+          <Copy className="w-4 h-4" />
+        </button>
+        <button
+          onClick={handleDocx}
+          className="p-2 bg-gray-100 hover:bg-gray-200 rounded transition-colors"
+          title="Download .docx"
+        >
+          <FileText className="w-4 h-4" />
+        </button>
+        <button
+          onClick={handlePdf}
+          className="p-2 bg-gray-100 hover:bg-gray-200 rounded transition-colors"
+          title="Download .pdf"
+        >
+          <FileDown className="w-4 h-4" />
+        </button>
+      </div>
+
+      <h1 className="text-2xl font-bold">{metadata.title}</h1>
+      <p className="text-sm text-gray-600">
+        {metadata.date} • {metadata.baan} • {metadata.sector}/{metadata.niveau}
+      </p>
+
+      {sections.map((section) => (
+        <div key={section.title} className="mt-4">
+          <h2 className="text-xl font-semibold mb-2">{section.title}</h2>
+          <p className="text-gray-700 whitespace-pre-line">{section.content}</p>
+        </div>
+      ))}
+
+      {copied && (
+        <div className="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow-lg">
+          Gekopieerd!
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/lib/export.ts
+++ b/Leerdoelengenerator-main/src/lib/export.ts
@@ -1,0 +1,69 @@
+import { saveAs } from 'file-saver';
+import { Document, Packer, Paragraph, HeadingLevel } from 'docx';
+import jsPDF from 'jspdf';
+
+export interface ExportMetadata {
+  title: string;
+  date: string;
+  baan: string;
+  sector: string;
+  niveau: string;
+}
+
+export interface ExportSection {
+  title: string;
+  content: string;
+}
+
+export async function exportToDocx(metadata: ExportMetadata, sections: ExportSection[]): Promise<void> {
+  const doc = new Document({
+    sections: [
+      {
+        children: [
+          new Paragraph({ text: metadata.title, heading: HeadingLevel.HEADING_1 }),
+          new Paragraph({ text: `Datum: ${metadata.date}` }),
+          new Paragraph({ text: `Baan: ${metadata.baan}` }),
+          new Paragraph({ text: `Sector/Niveau: ${metadata.sector} / ${metadata.niveau}` }),
+          ...sections.flatMap((section, idx) => [
+            new Paragraph({ text: section.title, heading: HeadingLevel.HEADING_2, pageBreakBefore: idx !== 0 }),
+            new Paragraph({ text: section.content }),
+          ]),
+        ],
+      },
+    ],
+  });
+
+  const blob = await Packer.toBlob(doc);
+  saveAs(blob, `${metadata.title}.docx`);
+}
+
+export function exportToPdf(metadata: ExportMetadata, sections: ExportSection[]): void {
+  const doc = new jsPDF();
+  doc.setProperties({ title: metadata.title });
+  doc.setFont('Helvetica', 'normal');
+  let y = 20;
+
+  doc.setFontSize(18);
+  doc.text(metadata.title, 10, y);
+  y += 10;
+
+  doc.setFontSize(12);
+  doc.text(`Datum: ${metadata.date}`, 10, y);
+  y += 6;
+  doc.text(`Baan: ${metadata.baan}`, 10, y);
+  y += 6;
+  doc.text(`Sector/Niveau: ${metadata.sector} / ${metadata.niveau}`, 10, y);
+
+  sections.forEach((section) => {
+    doc.addPage();
+    y = 20;
+    doc.setFontSize(16);
+    doc.text(section.title, 10, y);
+    y += 10;
+    doc.setFontSize(12);
+    const lines = doc.splitTextToSize(section.content, 180);
+    doc.text(lines, 10, y);
+  });
+
+  doc.save(`${metadata.title}.pdf`);
+}


### PR DESCRIPTION
## Summary
- add ResultCard component with copy and download buttons
- implement PDF/DOCX export utilities

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 17 errors)

------
https://chatgpt.com/codex/tasks/task_e_68a345a26e0c8330935c910ff2e02760