### PR TITLE
Add basic KD text parser with fixtures

### DIFF
--- a/Leerdoelengenerator-main/fixtures/kd_sample_text.txt
+++ b/Leerdoelengenerator-main/fixtures/kd_sample_text.txt
@@ -1,0 +1,10 @@
+KD Softwaredeveloper 2024
+
+Kerntaak 1 Ontwikkelt software
+Werkproces 1.1 Ontwerpt en plant werkzaamheden
+Resultaat:
+- Het ontwerp sluit aan op de klantvraag.
+Kwaliteitscriteria:
+- Hanteert versiebeheer en code-conventies.
+Gedragsindicatoren:
+- Werkt nauwkeurig en proactief.

--- a/Leerdoelengenerator-main/fixtures/kd_scanned_sample.pdf
+++ b/Leerdoelengenerator-main/fixtures/kd_scanned_sample.pdf
@@ -1,0 +1,21 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000100 00000 n 
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+147
+%%EOF

--- a/Leerdoelengenerator-main/src/services/kdParser.test.ts
+++ b/Leerdoelengenerator-main/src/services/kdParser.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { parseKdText } from './kdParser';
+
+const fixture = readFileSync('fixtures/kd_sample_text.txt', 'utf-8');
+
+describe('parseKdText', () => {
+  const result = parseKdText(fixture);
+  it('parses core task and work process', () => {
+    expect(result.coreTasks.length).toBe(1);
+    expect(result.coreTasks[0].workProcesses.length).toBe(1);
+  });
+
+  it('parses criteria with bullet list', () => {
+    const wp = result.coreTasks[0].workProcesses[0];
+    expect(wp.criteria.length).toBe(3);
+    expect(wp.criteria.map((c) => c.type)).toEqual([
+      'result',
+      'quality',
+      'behavior',
+    ]);
+  });
+});

--- a/Leerdoelengenerator-main/src/services/kdParser.ts
+++ b/Leerdoelengenerator-main/src/services/kdParser.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'crypto';
+import type { Qualification, CoreTask, WorkProcess, Criterion, CriterionType } from '../types/qualification';
+
+// Simple text-based parser for qualification dossiers.
+// Expects already extracted plain text.
+export function parseKdText(text: string): Qualification {
+  const lines = text.split(/\r?\n/).map((l) => l.trim());
+  const titleLine = lines.shift() || '';
+  const versionMatch = titleLine.match(/(20\d{2})/);
+  const qualification: Qualification = {
+    id: randomUUID(),
+    title: titleLine.replace(/\s*20\d{2}.*/, '').trim() || 'Onbekend',
+    version: versionMatch ? versionMatch[1] : null,
+    coreTasks: [],
+  };
+
+  let currentCore: CoreTask | null = null;
+  let currentWp: WorkProcess | null = null;
+  let currentType: CriterionType | null = null;
+
+  lines.forEach((rawLine) => {
+    const line = rawLine.trim();
+    if (!line) return;
+
+    const ctMatch = line.match(/^Kerntaak\s+(\d+)(?:\s+(.*))?/i);
+    if (ctMatch) {
+      currentCore = {
+        id: randomUUID(),
+        code: `Kerntaak ${ctMatch[1]}`,
+        title: ctMatch[2] ? ctMatch[2].trim() : '',
+        order: qualification.coreTasks.length + 1,
+        workProcesses: [],
+      };
+      qualification.coreTasks.push(currentCore);
+      currentWp = null;
+      currentType = null;
+      return;
+    }
+
+    const wpMatch = line.match(/^Werkproces\s+(\d+\.\d+)(?:\s+(.*))?/i);
+    if (wpMatch && currentCore) {
+      currentWp = {
+        id: randomUUID(),
+        code: wpMatch[1],
+        title: wpMatch[2] ? wpMatch[2].trim() : '',
+        order: currentCore.workProcesses.length + 1,
+        criteria: [],
+      };
+      currentCore.workProcesses.push(currentWp);
+      currentType = null;
+      return;
+    }
+
+    const header = line.toLowerCase();
+    if (header.startsWith('resultaat')) {
+      currentType = 'result';
+      return;
+    }
+    if (header.startsWith('kwaliteits')) {
+      currentType = 'quality';
+      return;
+    }
+    if (header.startsWith('gedrags')) {
+      currentType = 'behavior';
+      return;
+    }
+
+    if (/^[\-\u2022]/.test(line) && currentWp && currentType) {
+      const text = line.replace(/^[-\u2022]\s*/, '');
+      const crit: Criterion = {
+        id: randomUUID(),
+        type: currentType,
+        text,
+        order: currentWp.criteria.length + 1,
+      };
+      currentWp.criteria.push(crit);
+    }
+  });
+
+  return qualification;
+}

--- a/Leerdoelengenerator-main/src/types/qualification.ts
+++ b/Leerdoelengenerator-main/src/types/qualification.ts
@@ -1,0 +1,31 @@
+export interface Qualification {
+  id: string;
+  title: string;
+  version: string | null;
+  coreTasks: CoreTask[];
+}
+
+export interface CoreTask {
+  id: string;
+  code: string;
+  title: string;
+  order: number;
+  workProcesses: WorkProcess[];
+}
+
+export interface WorkProcess {
+  id: string;
+  code: string;
+  title: string;
+  order: number;
+  criteria: Criterion[];
+}
+
+export type CriterionType = 'result' | 'quality' | 'behavior' | 'other';
+
+export interface Criterion {
+  id: string;
+  type: CriterionType;
+  text: string;
+  order: number;
+}


### PR DESCRIPTION
## Summary
- add Qualification-related types
- implement simple text-based KD parser recognizing core tasks, work processes, and criteria
- include fixtures and initial parser tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a38c277b5883309a11150072d03a92