### PR TITLE
feat: add promotional footer

### DIFF
--- a/Leerdoelengenerator-main/src/components/Layout.tsx
+++ b/Leerdoelengenerator-main/src/components/Layout.tsx
@@ -1,0 +1,17 @@
+import type { FC, ReactNode } from "react";
+import PromoFooter from "./PromoFooter";
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const Layout: FC<LayoutProps> = ({ children }) => {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <div className="flex-1 flex flex-col">{children}</div>
+      <PromoFooter />
+    </div>
+  );
+};
+
+export default Layout;

--- a/Leerdoelengenerator-main/src/components/PromoFooter.tsx
+++ b/Leerdoelengenerator-main/src/components/PromoFooter.tsx
@@ -1,0 +1,26 @@
+import { ArrowUpRight, Settings } from "lucide-react";
+import type { FC } from "react";
+
+const PromoFooter: FC = () => {
+  return (
+    <footer
+      data-testid="promo-footer"
+      className="mt-8 w-full h-12 md:h-14 flex items-center justify-center px-4 text-xs sm:text-sm text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-sm hover:shadow-md transition-shadow"
+    >
+      <Settings className="w-4 h-4 mr-2 text-gray-500 dark:text-gray-400" aria-hidden="true" />
+      <span className="mr-1">Gemaakt door DigitEd — bekijk</span>
+      <a
+        href="https://www.digited.nl?utm_source=leerdoelen.digited.nl&utm_medium=footer&utm_campaign=site_promo"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Bezoek digited.nl (opent in nieuw tabblad)"
+        className="inline-flex items-center text-green-700 dark:text-green-400 underline focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 rounded"
+      >
+        digited.nl
+        <ArrowUpRight className="w-4 h-4 ml-1" aria-hidden="true" />
+      </a>
+    </footer>
+  );
+};
+
+export default PromoFooter;

--- a/Leerdoelengenerator-main/src/main.tsx
+++ b/Leerdoelengenerator-main/src/main.tsx
@@ -2,13 +2,19 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import About from './pages/About.tsx';
+import Layout from './components/Layout.tsx';
 import './index.css';
 
 const rootElement = document.getElementById('root')!;
 
 function Router() {
   const path = window.location.pathname;
-  return path === '/over' ? <About /> : <App />;
+  const Page = path === '/over' ? About : App;
+  return (
+    <Layout>
+      <Page />
+    </Layout>
+  );
 }
 
 createRoot(rootElement).render(


### PR DESCRIPTION
## Summary
- add reusable `PromoFooter` with link to digited.nl
- wrap app pages in `Layout` to show footer site-wide

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68a3942ad4848330b3e3bdccfd3ea4d1