### PR TITLE
Add Dutch learning objective normalizer

### DIFF
--- a/Leerdoelengenerator-main/src/lib/format.ts
+++ b/Leerdoelengenerator-main/src/lib/format.ts
@@ -1,3 +1,5 @@
+import { normalizeObjective } from "./nlGoals";
+
 export interface SMARTCheck {
   badge: "✅" | "❌";
   issues: string[];
@@ -34,7 +36,7 @@ export function enforceDutchAndSMART(
       .replace(/\bstudent\b/gi, "student");
   };
 
-  const newObjective = replaceEnglish(res.newObjective.trim());
+  const newObjective = normalizeObjective(replaceEnglish(res.newObjective.trim()));
   let rationale = replaceEnglish(res.rationale.trim());
   let activities = res.activities.map(a => replaceEnglish(a.trim())).filter(Boolean);
   let assessments = res.assessments.map(a => replaceEnglish(a.trim())).filter(Boolean);

--- a/Leerdoelengenerator-main/src/lib/nlGoals.test.ts
+++ b/Leerdoelengenerator-main/src/lib/nlGoals.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { normalizeObjective } from "./nlGoals";
+
+describe("normalizeObjective", () => {
+  it("replaces vague verb and adds placeholders", () => {
+    expect(normalizeObjective("De student begrijpt AI"))
+      .toBe("De student verklaart AI in [situatie] volgens [criterium]");
+  });
+
+  it("keeps existing context", () => {
+    expect(normalizeObjective("De student kent de theorie in de praktijk"))
+      .toBe("De student beschrijft de theorie in de praktijk volgens [criterium]");
+  });
+
+  it("keeps existing criterion", () => {
+    expect(normalizeObjective("De student weet de regels volgens examen"))
+      .toBe("De student beschrijft de regels volgens examen");
+  });
+
+  it("detects numeric criterion", () => {
+    expect(normalizeObjective("De student leert samenwerken tot 80%"))
+      .toBe("De student oefent samenwerken tot 80% in [situatie]");
+  });
+
+  it("adds both placeholders when missing", () => {
+    expect(normalizeObjective("De student kent Python"))
+      .toBe("De student beschrijft Python in [situatie] volgens [criterium]");
+  });
+
+  it("works for VO niveau", () => {
+    expect(normalizeObjective("De leerling weet de stelling"))
+      .toBe("De leerling beschrijft de stelling in [situatie] volgens [criterium]");
+  });
+
+  it("works for MBO product", () => {
+    expect(normalizeObjective("Student leert een website"))
+      .toBe("Student oefent een website in [situatie] volgens [criterium]");
+  });
+
+  it("works for HBO proces", () => {
+    expect(normalizeObjective("De student begrijpt projectmanagement"))
+      .toBe("De student verklaart projectmanagement in [situatie] volgens [criterium]");
+  });
+
+  it("works for WO onderzoek", () => {
+    expect(normalizeObjective("De onderzoeker kent statistiek"))
+      .toBe("De onderzoeker beschrijft statistiek in [situatie] volgens [criterium]");
+  });
+
+  it("does not add context twice", () => {
+    expect(normalizeObjective("De student kent theorie binnen het lab"))
+      .toBe("De student beschrijft theorie binnen het lab volgens [criterium]");
+  });
+
+  it("does not add criterion if aanwezig", () => {
+    expect(normalizeObjective("De student weet theorie volgens schema"))
+      .toBe("De student beschrijft theorie volgens schema");
+  });
+
+  it("handles uppercase verbs", () => {
+    expect(normalizeObjective("DE STUDENT BEGRIJPT DATA"))
+      .toBe("DE STUDENT verklaart DATA in [situatie] volgens [criterium]");
+  });
+
+  it("handles extra spaces", () => {
+    expect(normalizeObjective("  student weet  feiten  "))
+      .toBe("student beschrijft feiten in [situatie] volgens [criterium]");
+  });
+
+  it("leaves observable verb untouched", () => {
+    expect(normalizeObjective("De student analyseert data"))
+      .toBe("De student analyseert data in [situatie] volgens [criterium]");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeObjective(""))
+      .toBe("");
+  });
+});

--- a/Leerdoelengenerator-main/src/lib/nlGoals.ts
+++ b/Leerdoelengenerator-main/src/lib/nlGoals.ts
@@ -1,0 +1,46 @@
+export const vagueVerbMap: Record<string, string> = {
+  "begrijpt": "verklaart",
+  "begrijpen": "verklaren",
+  "weet": "beschrijft",
+  "weten": "beschrijven",
+  "kent": "beschrijft",
+  "kennen": "beschrijven",
+  "leert": "oefent",
+  "leren": "oefenen"
+};
+
+/**
+ * Normalize a Dutch learning objective so it matches common conventions:
+ * - Replace vague verbs with observable alternatives
+ * - Ensure context ("in [situatie]") and criterion ("volgens [criterium]")
+ *   placeholders when missing
+ */
+export function normalizeObjective(text: string): string {
+  if (!text) return "";
+  let result = text.trim();
+
+  // Replace vague verbs
+  for (const [vague, observable] of Object.entries(vagueVerbMap)) {
+    const rx = new RegExp(`\\b${vague}\\b`, "i");
+    if (rx.test(result)) {
+      result = result.replace(rx, observable);
+      break;
+    }
+  }
+
+  // Check context presence
+  const hasContext = /\b(in|binnen)\b/i.test(result);
+  if (!hasContext) {
+    result = `${result} in [situatie]`;
+  }
+
+  // Check criterion presence (numbers, percentage, criterium, volgens)
+  const hasCriterion = /(\d+\s*(%|keer)?|criterium|score|cijfer|volgens)/i.test(result);
+  if (!hasCriterion) {
+    result = `${result} volgens [criterium]`;
+  }
+
+  return result.trim();
+}
+
+export default normalizeObjective;


### PR DESCRIPTION
## Summary
- introduce `normalizeObjective` utility to replace vague verbs and add context/criterion placeholders
- apply normalizer within Dutch & SMART post-processing pipeline
- add comprehensive Vitest suite for `normalizeObjective`

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd201bf0833090137540df36e614