### PR TITLE
Format Bloom levels in Dutch

### DIFF
--- a/Leerdoelengenerator-main/README.md
+++ b/Leerdoelengenerator-main/README.md
@@ -1,1 +1,7 @@
 Leerdoelengenerator
+
+## UI-conventies Bloom (NL)
+
+Bloom-niveaus worden in de interface weergegeven als Nederlandse labels met een korte uitleg.
+Voorbeeld: `Niveau volgens Bloom: Toepassen — de student gebruikt kennis in een praktische situatie.`
+Bij meerdere niveaus worden labels en beschrijvingen door komma's en "en" gescheiden.

--- a/Leerdoelengenerator-main/src/components/ResultCard.tsx
+++ b/Leerdoelengenerator-main/src/components/ResultCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { PostProcessedResponse } from '../lib/format';
+import { formatBloom } from '../utils/bloom';
 
 interface ResultCardProps {
   result?: PostProcessedResponse;
@@ -24,6 +25,7 @@ export const ResultCard: React.FC<ResultCardProps> = ({ result, error, onSave })
   const autoFixed = result.warnings.includes('Automatisch hersteld');
   const remainingWarnings = result.warnings.filter(w => w !== 'Automatisch hersteld');
   const isIncomplete = !result.newObjective || !result.rationale;
+  const bloom = formatBloom(result.bloom);
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-100 p-4">
@@ -35,6 +37,11 @@ export const ResultCard: React.FC<ResultCardProps> = ({ result, error, onSave })
 
       <h3 className="font-semibold text-gray-900 mb-2">AI-ready leerdoel</h3>
       <p className="text-gray-700 mb-4">{result.newObjective}</p>
+      {bloom && (
+        <p className="text-gray-700 mb-4">
+          <strong>{bloom.label}</strong> — {bloom.description}
+        </p>
+      )}
 
       <h4 className="font-medium text-gray-900 mb-1">Rationale</h4>
       <p className="text-gray-700 mb-4">{result.rationale}</p>

--- a/Leerdoelengenerator-main/src/lib/format.ts
+++ b/Leerdoelengenerator-main/src/lib/format.ts
@@ -11,6 +11,7 @@ export interface PostProcessedResponse {
   activities: string[];
   assessments: string[];
   aiLiteracy: string;
+  bloom?: string;
   aiLiteracyFocus: string[];
   smart: SMARTCheck;
   warnings: string[];
@@ -22,7 +23,14 @@ export interface PostProcessedResponse {
  * (kritisch denken, ethiek). Inspired by Npuls Two-Lane approach and AI-GO checklists.
  */
 export function enforceDutchAndSMART(
-  res: { newObjective: string; rationale: string; activities: string[]; assessments: string[]; aiLiteracy?: string },
+  res: {
+    newObjective: string;
+    rationale: string;
+    activities: string[];
+    assessments: string[];
+    aiLiteracy?: string;
+    bloom?: string;
+  },
   lane: "baan1" | "baan2" = "baan1"
 ): PostProcessedResponse {
   const warnings: string[] = [];
@@ -41,6 +49,7 @@ export function enforceDutchAndSMART(
   let activities = res.activities.map(a => replaceEnglish(a.trim())).filter(Boolean);
   let assessments = res.assessments.map(a => replaceEnglish(a.trim())).filter(Boolean);
   const aiLiteracy = replaceEnglish(res.aiLiteracy?.trim() || "");
+  const bloom = res.bloom?.trim();
 
   const englishPattern = /\b(the|and|with|without|to|for|on)\b/i;
   if (englishPattern.test([newObjective, rationale, activities.join(" "), assessments.join(" "), aiLiteracy].join(" "))) {
@@ -104,6 +113,7 @@ export function enforceDutchAndSMART(
     activities,
     assessments,
     aiLiteracy,
+    bloom,
     aiLiteracyFocus,
     smart: { badge: smartBadge, issues },
     warnings,

--- a/Leerdoelengenerator-main/src/services/gemini.ts
+++ b/Leerdoelengenerator-main/src/services/gemini.ts
@@ -11,6 +11,7 @@ export interface GeminiResponse {
   activities: string[];
   assessments: string[];
   aiLiteracy: string;
+  bloom?: string;
 }
 
 export interface KDContext {
@@ -111,6 +112,7 @@ export function buildPrompt(ctx: LearningObjectiveContext, kd?: KDContext): stri
     ' "rationale": "... (≤80 woorden)",',
     ' "activities": ["…","…","…"],',
     ' "assessments": ["[Baan X] …","…"],',
+    ' "bloom": "apply",',
     ' "aiLiteracy": "Kernpunten (kritisch denken/ethiek/vaardigheden)"',
     "}"
   ].filter(Boolean).join("\n");
@@ -189,7 +191,8 @@ export async function generateAIReadyObjective(
       rationale: String(data.rationale ?? ""),
       activities: Array.isArray(data.activities) ? data.activities.map(String) : [],
       assessments: Array.isArray(data.assessments) ? data.assessments.map(String) : [],
-      aiLiteracy: String(data.aiLiteracy ?? "")
+      aiLiteracy: String(data.aiLiteracy ?? ""),
+      bloom: data.bloom ? String(data.bloom) : undefined
     };
 
     // Minimale validatie

--- a/Leerdoelengenerator-main/src/utils/bloom.test.ts
+++ b/Leerdoelengenerator-main/src/utils/bloom.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { formatBloom } from './bloom';
+
+describe('formatBloom', () => {
+  it('returns null for empty input', () => {
+    expect(formatBloom('')).toBeNull();
+  });
+
+  it('formats single level', () => {
+    const res = formatBloom('apply');
+    expect(res).not.toBeNull();
+    expect(res!.label).toBe('Niveau volgens Bloom: Toepassen');
+    expect(res!.description).toContain('praktische situatie');
+  });
+
+  it('formats multiple levels', () => {
+    const res = formatBloom('rememberUnderstand • apply');
+    expect(res).not.toBeNull();
+    expect(res!.label).toBe('Niveau volgens Bloom: Onthouden, Begrijpen en Toepassen');
+  });
+
+  it('handles various separators', () => {
+    const res = formatBloom('Analyze;Evaluate');
+    expect(res).not.toBeNull();
+    expect(res!.label).toBe('Niveau volgens Bloom: Analyseren en Evalueren');
+  });
+
+  it('splits camelCase combos', () => {
+    const res = formatBloom('REMEMBERUNDERSTAND');
+    expect(res).not.toBeNull();
+    expect(res!.label).toBe('Niveau volgens Bloom: Onthouden en Begrijpen');
+  });
+});

--- a/Leerdoelengenerator-main/src/utils/bloom.ts
+++ b/Leerdoelengenerator-main/src/utils/bloom.ts
@@ -1,0 +1,39 @@
+export type BloomKey = 'remember' | 'understand' | 'apply' | 'analyze' | 'evaluate' | 'create';
+
+const MAP: Record<BloomKey, { nl: string; desc: string }> = {
+  remember: { nl: 'Onthouden', desc: 'de student herinnert of benoemt basiskennis' },
+  understand: { nl: 'Begrijpen', desc: 'de student legt uit in eigen woorden of licht toe' },
+  apply: { nl: 'Toepassen', desc: 'de student gebruikt kennis in een praktische situatie' },
+  analyze: { nl: 'Analyseren', desc: 'de student onderzoekt, vergelijkt of legt verbanden' },
+  evaluate: { nl: 'Evalueren', desc: 'de student beoordeelt, beargumenteert of trekt conclusies' },
+  create: { nl: 'Creëren', desc: 'de student ontwerpt, ontwikkelt of bedenkt iets nieuws' },
+};
+
+function join(items: string[]): string {
+  if (items.length <= 1) return items[0];
+  return `${items.slice(0, -1).join(', ')} en ${items.slice(-1)[0]}`;
+}
+
+export function formatBloom(raw?: string): { label: string; description: string } | null {
+  if (!raw) return null;
+
+  const spaced = raw.replace(/([a-z])([A-Z])/g, '$1 $2');
+  const tokens = spaced.toLowerCase().split(/[^\p{L}]+/u).filter(Boolean);
+
+  const expanded = tokens.flatMap(t =>
+    t.includes('rememberunderstand') ? ['remember', 'understand'] : t
+  );
+
+  const keys = Array.from(new Set(expanded)).filter((k): k is BloomKey => k in MAP);
+  if (keys.length === 0) return null;
+
+  const labels = keys.map(k => MAP[k].nl);
+  const descs = keys.map(k => MAP[k].desc);
+
+  return {
+    label: `Niveau volgens Bloom: ${join(labels)}`,
+    description: `${join(descs)}.`,
+  };
+}
+
+export default formatBloom;


### PR DESCRIPTION
## Summary
- add `formatBloom` util to normalize and map Bloom levels to Dutch labels and descriptions
- display Bloom levels in result cards using Dutch text
- document Bloom UI convention in README

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a595a9d6ac8330a6b99df5c8fc8b21