### PR TITLE
feat: add automatic level check with Bloom detection

### DIFF
--- a/Leerdoelengenerator-main/src/utils/niveauCheck.test.ts
+++ b/Leerdoelengenerator-main/src/utils/niveauCheck.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { checkLevelFit } from './niveauCheck';
+
+describe('checkLevelFit', () => {
+  it('vmbo-basis analyseert -> te_hoog and verb tip', () => {
+    const res = checkLevelFit('Analyseert de oorzaken van klimaatverandering.', 'VO:vmbo-basis');
+    expect(res.fit).toBe('te_hoog');
+    expect(res.messages[0]).toBe("Begin met een passend, meetbaar werkwoord voor dit niveau (bv. 'noemt').");
+  });
+
+  it('havo past toe with norm and autonomy >35 words -> length tip only', () => {
+    const obj = 'Past toe de geleerde rekenstrategieën bij drie verschillende complexe vraagstukken in de les, volgens de rubric voor nauwkeurigheid en volledigheid van het examen, volledig zelfstandig en binnen de door de docent gestelde tijd van 15 minuten.';
+    const res = checkLevelFit(obj, 'VO:havo');
+    expect(res.fit).toBe('passend');
+    expect(res.messages).toEqual(['Leerdoel is te lang; formuleer compacter.']);
+  });
+
+  it('vwo evaluate and create -> bloom label', () => {
+    const obj = 'Evalueert en ontwerpt een onderzoeksopzet volgens rubric, binnen 2 weken zelfstandig.';
+    const res = checkLevelFit(obj, 'VO:vwo');
+    expect(res.fit).toBe('passend');
+    expect(res.bloomLabelNl).toBe('Niveau volgens Bloom: Evalueren en Creëren');
+  });
+
+  it('VSO arbeidsmarktgericht zonder norm -> measurability tip', () => {
+    const obj = 'Gebruikt gereedschap volgens veiligheidsinstructies onder begeleiding.';
+    const res = checkLevelFit(obj, 'VSO:arbeidsmarktgericht');
+    expect(res.messages).toContain('Maak het doel meetbaar (hoeveel/hoe goed/wanneer).');
+  });
+
+  it('MBO-2 analyseert -> te_hoog', () => {
+    const res = checkLevelFit('Analyseert markttrends.', 'MBO:2');
+    expect(res.fit).toBe('te_hoog');
+  });
+
+  it('WO Master creëert -> passend', () => {
+    const res = checkLevelFit('Creëert een nieuw model volgens rubric binnen 10 weken zelfstandig.', 'WO:Master');
+    expect(res.fit).toBe('passend');
+  });
+
+  it('heuristic detection works with empty bloom input', () => {
+    const res = checkLevelFit('Analyseert gegevens zorgvuldig.', 'MBO:3', '');
+    expect(res.detectedBlooms).toContain('analyze');
+  });
+});

--- a/Leerdoelengenerator-main/src/utils/niveauCheck.ts
+++ b/Leerdoelengenerator-main/src/utils/niveauCheck.ts
@@ -1,0 +1,186 @@
+export type BloomKey = 'remember'|'understand'|'apply'|'analyze'|'evaluate'|'create';
+
+export const BLOOM_NL: Record<BloomKey, {nl: string; desc: string}> = {
+  remember:   { nl: 'Onthouden',  desc: 'de student herinnert of benoemt basiskennis' },
+  understand: { nl: 'Begrijpen',  desc: 'de student legt uit in eigen woorden of licht toe' },
+  apply:      { nl: 'Toepassen',  desc: 'de student gebruikt kennis in een praktische situatie' },
+  analyze:    { nl: 'Analyseren', desc: 'de student onderzoekt, vergelijkt of legt verbanden' },
+  evaluate:   { nl: 'Evalueren',  desc: 'de student beoordeelt, beargumenteert of trekt conclusies' },
+  create:     { nl: 'Creëren',    desc: 'de student ontwerpt, ontwikkelt of bedenkt iets nieuws' },
+};
+
+export const DUTCH_VERBS: Record<BloomKey, string[]> = {
+  remember:   ['noemt','beschrijft','definieert','herkent'],
+  understand: ['legt uit','licht toe','vat samen','interpreteert'],
+  apply:      ['past toe','gebruikt','toepassen','hanteert'],
+  analyze:    ['analyseert','vergelijkt','ordent','maakt onderscheid'],
+  evaluate:   ['beoordeelt','onderbouwt','evalueert','kritiseert'],
+  create:     ['ontwerpt','ontwikkelt','formuleert','creëert'],
+};
+
+export type LevelKey =
+  | 'VSO:dagbesteding' | 'VSO:arbeidsmarktgericht' | 'VSO:vervolgonderwijs'
+  | 'VO:vmbo-basis' | 'VO:vmbo-kader' | 'VO:vmbo-gemengde' | 'VO:vmbo-theoretische' | 'VO:havo' | 'VO:vwo'
+  | 'MBO:1' | 'MBO:2' | 'MBO:3' | 'MBO:4'
+  | 'HBO:AD' | 'HBO:Bachelor' | 'HBO:Master'
+  | 'WO:Bachelor' | 'WO:Master';
+
+export const expectedBloomBands: Record<LevelKey, BloomKey[]> = {
+  // VSO
+  'VSO:dagbesteding':        ['remember','understand'],
+  'VSO:arbeidsmarktgericht': ['remember','understand','apply'],
+  'VSO:vervolgonderwijs':    ['understand','apply','analyze'],
+
+  // VO
+  'VO:vmbo-basis':           ['remember','understand','apply'],
+  'VO:vmbo-kader':           ['remember','understand','apply'],
+  'VO:vmbo-gemengde':        ['understand','apply','analyze'],
+  'VO:vmbo-theoretische':    ['understand','apply','analyze'],
+  'VO:havo':                 ['apply','analyze','evaluate'],
+  'VO:vwo':                  ['analyze','evaluate','create'],
+
+  // MBO
+  'MBO:1':                   ['remember','understand'],
+  'MBO:2':                   ['remember','understand','apply'],
+  'MBO:3':                   ['understand','apply','analyze'],
+  'MBO:4':                   ['apply','analyze','evaluate'],
+
+  // HBO
+  'HBO:AD':                  ['apply','analyze'],
+  'HBO:Bachelor':            ['analyze','evaluate','create'],
+  'HBO:Master':              ['evaluate','create'],
+
+  // WO
+  'WO:Bachelor':             ['analyze','evaluate'],
+  'WO:Master':               ['evaluate','create'],
+};
+
+const BLOOM_ORDER: BloomKey[] = ['remember','understand','apply','analyze','evaluate','create'];
+
+export function nlJoin(arr: string[]): string {
+  if (arr.length <= 1) return arr[0] ?? '';
+  return `${arr.slice(0, -1).join(', ')} en ${arr[arr.length - 1]}`;
+}
+
+export function parseBloom(raw?: string): BloomKey[] {
+  if (!raw) return [];
+  const spaced = raw.replace(/(\p{Ll})(\p{Lu})/gu, '$1 $2');
+  const tokens = spaced.toLowerCase().split(/[^\p{L}]+/u).filter(Boolean);
+  const expanded = tokens.flatMap(t => t === 'rememberunderstand' ? ['remember','understand'] : t);
+  const unique = Array.from(new Set(expanded));
+  return unique.filter((t): t is BloomKey => (BLOOM_ORDER as string[]).includes(t));
+}
+
+export function detectDutchBloom(text: string): BloomKey[] {
+  const found: BloomKey[] = [];
+  const lower = text.toLowerCase();
+  for (const key of BLOOM_ORDER) {
+    for (const verb of DUTCH_VERBS[key]) {
+      const re = new RegExp(`\\b${verb}\\b`, 'i');
+      if (re.test(lower)) {
+        found.push(key);
+        break;
+      }
+    }
+  }
+  return Array.from(new Set(found));
+}
+
+export function formatBloomNl(keys: BloomKey[]): { label: string; desc: string } {
+  const labels = keys.map(k => BLOOM_NL[k].nl);
+  const descs = keys.map(k => BLOOM_NL[k].desc);
+  return {
+    label: `Niveau volgens Bloom: ${nlJoin(labels)}`,
+    desc: `— ${nlJoin(descs)}`,
+  };
+}
+
+export interface NiveauCheckResult {
+  fit: 'passend' | 'te_hoog' | 'te_laag' | 'gemengd';
+  detectedBlooms: BloomKey[];
+  expectedBlooms: BloomKey[];
+  messages: string[];
+  autosuggest?: string;
+  bloomLabelNl: string;
+  bloomDescNl: string;
+}
+
+function bloomIndex(k: BloomKey): number {
+  return BLOOM_ORDER.indexOf(k);
+}
+
+export function checkLevelFit(
+  learningObjective: string,
+  chosenLevel: LevelKey,
+  modelBloom?: string
+): NiveauCheckResult {
+  const parsed = parseBloom(modelBloom);
+  const heuristic = detectDutchBloom(learningObjective);
+  const detected = Array.from(new Set([...parsed, ...heuristic]));
+  const expected = expectedBloomBands[chosenLevel];
+
+  let fit: NiveauCheckResult['fit'] = 'passend';
+  if (detected.length === 0 || detected.every(b => expected.includes(b))) {
+    fit = 'passend';
+  } else if (detected.some(b => bloomIndex(b) > Math.max(...expected.map(bloomIndex)))) {
+    fit = 'te_hoog';
+  } else if (detected.every(b => bloomIndex(b) < Math.min(...expected.map(bloomIndex)))) {
+    fit = 'te_laag';
+  } else {
+    fit = 'gemengd';
+  }
+
+  const messages: string[] = [];
+  const wordCount = learningObjective.trim().split(/\s+/).filter(Boolean).length;
+  if (wordCount > 35) {
+    messages.push('Leerdoel is te lang; formuleer compacter.');
+  }
+
+  const lowestVerb = DUTCH_VERBS[expected[0]][0];
+  let startBloom: BloomKey | null = null;
+  for (const key of BLOOM_ORDER) {
+    for (const verb of DUTCH_VERBS[key]) {
+      const re = new RegExp(`^\s*${verb}\\b`, 'i');
+      if (re.test(learningObjective)) {
+        startBloom = key;
+        break;
+      }
+    }
+    if (startBloom) break;
+  }
+  if (!startBloom || !expected.includes(startBloom)) {
+    messages.push(`Begin met een passend, meetbaar werkwoord voor dit niveau (bv. '${lowestVerb}').`);
+  }
+
+  const hasCriteria = /\b(volgens|checklist|rubric|criteria|conform)\b/i.test(learningObjective);
+  if (!hasCriteria) {
+    messages.push("Noem een criterium/kwaliteit (bijv. 'volgens checklist/rubric').");
+  }
+
+  const hasAutonomy = /\b(zelfstandig|onder begeleiding|met instructie|met feedback)\b/i.test(learningObjective);
+  if (!hasAutonomy) {
+    messages.push('Noem mate van zelfstandigheid/begeleiding.');
+  }
+
+  const hasMeasure = /\b\d+\b|%|\b(?:uur|uren|minuten?|dagen?|weken?|maanden?|jaren?)\b/i.test(learningObjective);
+  if (!hasMeasure) {
+    messages.push('Maak het doel meetbaar (hoeveel/hoe goed/wanneer).');
+  }
+
+  if (fit !== 'passend') {
+    const dir = fit === 'te_hoog' ? 'hoger' : fit === 'te_laag' ? 'lager' : 'hoger of lager';
+    messages.push(`Denkniveau (Bloom) ligt ${dir} dan gebruikelijk voor ${chosenLevel}.`);
+  }
+
+  const bloomDisplay = formatBloomNl(detected.length > 0 ? detected : expected);
+
+  return {
+    fit,
+    detectedBlooms: detected,
+    expectedBlooms: expected,
+    messages,
+    autosuggest: `${lowestVerb} [taak] volgens [criterium], [meetbare norm], [zelfstandigheid].`,
+    bloomLabelNl: bloomDisplay.label,
+    bloomDescNl: bloomDisplay.desc,
+  };
+}


### PR DESCRIPTION
## Summary
- implement `checkLevelFit` to assess Bloom fit for various education levels
- provide Dutch Bloom labels, verbs, and expected bands per level
- add tests covering Bloom fit scenarios and heuristics

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a250a2b08330b66e49f2f2727c59