### PR TITLE
Add DigitEd advertisement component

### DIFF
--- a/Leerdoelengenerator-main/src/components/DigitEdAd.tsx
+++ b/Leerdoelengenerator-main/src/components/DigitEdAd.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+const DigitEdAd: React.FC = () => {
+  return (
+    <div
+      className="border-2 border-[#247A38] rounded-2xl p-5 max-w-md mx-auto my-6 text-center shadow-sm hover:shadow-md transition-shadow"
+    >
+      <img
+        src="https://digited.nl/wp-content/uploads/2025/05/logo5.png"
+        alt="DigitEd logo"
+        width={240}
+        height={240}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        className="w-32 h-auto mx-auto mb-4"
+        onError={(e) => {
+          // Fallback: toon alleen de tekst als het extern logo niet laadt
+          (e.currentTarget as HTMLImageElement).style.display = "none";
+          const alt = document.createElement("div");
+          alt.textContent = "DigitEd";
+          alt.className = "text-2xl font-semibold text-[#247A38] mb-4";
+          e.currentTarget.parentElement?.insertBefore(alt, e.currentTarget.nextSibling);
+        }}
+      />
+      <h2 className="text-[#247A38] text-xl font-semibold mb-2">DigitEd</h2>
+      <p className="text-base leading-relaxed mb-4">
+        DigitEd helpt onderwijsprofessionals met praktische trainingen en begeleiding rond digitalisering en AI.
+        Met hands-on workshops en inspirerende tools maak je jouw onderwijs klaar voor de toekomst.
+      </p>
+      <div className="mt-2 flex flex-col sm:flex-row justify-center gap-3">
+        <a
+          href="https://digited.nl/contact/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="bg-[#247A38] text-white px-4 py-2 rounded-md font-bold hover:opacity-90 transition-opacity"
+        >
+          Neem contact op
+        </a>
+        <a
+          href="https://www.linkedin.com/in/edwinspielhagen"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="bg-[#E3701C] text-white px-4 py-2 rounded-md font-bold hover:opacity-90 transition-opacity"
+        >
+          Connect op LinkedIn
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default DigitEdAd;

--- a/Leerdoelengenerator-main/src/main.tsx
+++ b/Leerdoelengenerator-main/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App.tsx';
+import HomePage from './pages/index.tsx';
 import About from './pages/About.tsx';
 import Layout from './components/Layout.tsx';
 import './index.css';
@@ -9,7 +9,7 @@ const rootElement = document.getElementById('root')!;
 
 function Router() {
   const path = window.location.pathname;
-  const Page = path === '/over' ? About : App;
+  const Page = path === '/over' ? About : HomePage;
   return (
     <Layout>
       <Page />

--- a/Leerdoelengenerator-main/src/pages/index.tsx
+++ b/Leerdoelengenerator-main/src/pages/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import App from "../App";
+import DigitEdAd from "../components/DigitEdAd";
+
+const HomePage: React.FC = () => {
+  return (
+    <>
+      <App />
+      <DigitEdAd />
+    </>
+  );
+};
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- add DigitEdAd component with external logo, text and contact links
- display DigitEdAd on homepage via new page wrapper
- switch routing to use new homepage component

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a5f35728608330b6082f4e058227d2