### PR TITLE
Add public value explanations to generated learning objectives

### DIFF
--- a/Leerdoelengenerator-main/src/components/ResultCard.tsx
+++ b/Leerdoelengenerator-main/src/components/ResultCard.tsx
@@ -46,6 +46,9 @@ export const ResultCard: React.FC<ResultCardProps> = ({ result, error, onSave })
       <h4 className="font-medium text-gray-900 mb-1">Rationale</h4>
       <p className="text-gray-700 mb-4">{result.rationale}</p>
 
+      <h4 className="font-medium text-gray-900 mb-1">Publieke waarde</h4>
+      <p className="text-gray-700 mb-4">{result.publicValue}</p>
+
       {remainingWarnings.length > 0 && (
         <ul className="mb-4 p-2 bg-orange-50 border border-orange-200 rounded text-orange-800 text-sm list-disc list-inside">
           {remainingWarnings.map((w, idx) => (

--- a/Leerdoelengenerator-main/src/lib/format.ts
+++ b/Leerdoelengenerator-main/src/lib/format.ts
@@ -11,6 +11,7 @@ export interface PostProcessedResponse {
   activities: string[];
   assessments: string[];
   aiLiteracy: string;
+  publicValue: string;
   bloom?: string;
   aiLiteracyFocus: string[];
   smart: SMARTCheck;
@@ -29,6 +30,7 @@ export function enforceDutchAndSMART(
     activities: string[];
     assessments: string[];
     aiLiteracy?: string;
+    publicValue?: string;
     bloom?: string;
   },
   lane: "baan1" | "baan2" = "baan1"
@@ -49,10 +51,11 @@ export function enforceDutchAndSMART(
   let activities = res.activities.map(a => replaceEnglish(a.trim())).filter(Boolean);
   let assessments = res.assessments.map(a => replaceEnglish(a.trim())).filter(Boolean);
   const aiLiteracy = replaceEnglish(res.aiLiteracy?.trim() || "");
+  const publicValue = replaceEnglish(res.publicValue?.trim() || "");
   const bloom = res.bloom?.trim();
 
   const englishPattern = /\b(the|and|with|without|to|for|on)\b/i;
-  if (englishPattern.test([newObjective, rationale, activities.join(" "), assessments.join(" "), aiLiteracy].join(" "))) {
+  if (englishPattern.test([newObjective, rationale, activities.join(" "), assessments.join(" "), aiLiteracy, publicValue].join(" "))) {
     warnings.push("Niet alle tekst is in het Nederlands.");
   }
 
@@ -113,6 +116,7 @@ export function enforceDutchAndSMART(
     activities,
     assessments,
     aiLiteracy,
+    publicValue,
     bloom,
     aiLiteracyFocus,
     smart: { badge: smartBadge, issues },

--- a/Leerdoelengenerator-main/src/services/gemini.ts
+++ b/Leerdoelengenerator-main/src/services/gemini.ts
@@ -13,6 +13,7 @@ export interface GeminiResponse {
   activities: string[];
   assessments: string[];
   aiLiteracy: string;
+  publicValue: string;
   bloom?: string;
 }
 
@@ -111,6 +112,7 @@ export function buildPrompt(ctx: LearningObjectiveContext, kd?: KDContext): stri
     "- Constructive alignment; Two-Lane approach (Baan 1=besluitvormend, beperkte AI; Baan 2=ontwikkelingsgericht, AI toegestaan/verplicht).",
     "- AI-geletterdheid (AI-GO): benoem kort welke kennis/vaardigheden/ethiek aan bod komen.",
     "- Referentiekader 2.0: wees transparant en ethisch; geen persoonsgegevens; geen hallucinaties.",
+    "- Benoem in één zin welke publieke waarde (rechtvaardigheid, menselijkheid of autonomie) het nieuwe leerdoel ondersteunt en waarom.",
     "Eisen:",
     "- 1 leerdoel, actief werkwoord + context + meetcriterium + condities + tijd.",
     "- Geen Engels.",
@@ -126,7 +128,8 @@ export function buildPrompt(ctx: LearningObjectiveContext, kd?: KDContext): stri
     ' "activities": ["…","…","…"],',
     ' "assessments": ["[Baan X] …","…"],',
     ' "bloom": "apply",',
-    ' "aiLiteracy": "Kernpunten (kritisch denken/ethiek/vaardigheden)"',
+    ' "aiLiteracy": "Kernpunten (kritisch denken/ethiek/vaardigheden)",',
+    ' "publicValue": "Dit leerdoel sluit aan bij de waarde autonomie omdat ..."',
     "}"
   ].filter(Boolean).join("\n");
 }
@@ -205,11 +208,12 @@ export async function generateAIReadyObjective(
       activities: Array.isArray(data.activities) ? data.activities.map(String) : [],
       assessments: Array.isArray(data.assessments) ? data.assessments.map(String) : [],
       aiLiteracy: String(data.aiLiteracy ?? ""),
+      publicValue: String(data.publicValue ?? ""),
       bloom: data.bloom ? String(data.bloom) : undefined
     };
 
     // Minimale validatie
-    if (!safe.newObjective || safe.activities.length === 0 || !safe.aiLiteracy) {
+    if (!safe.newObjective || safe.activities.length === 0 || !safe.aiLiteracy || !safe.publicValue) {
       throw new Error("Onvolledige JSON-respons ontvangen van model.");
     }
 

--- a/Leerdoelengenerator-main/src/services/llm.ts
+++ b/Leerdoelengenerator-main/src/services/llm.ts
@@ -86,6 +86,7 @@ export async function generateNormalizedObjective(
     processed.activities = processed.activities.map(repl);
     processed.assessments = processed.assessments.map(repl);
     processed.aiLiteracy = repl(processed.aiLiteracy);
+    processed.publicValue = repl(processed.publicValue);
   }
   return processed;
 }


### PR DESCRIPTION
## Summary
- Extend Gemini prompt and response parsing to include a `publicValue` field linking objectives to justice, humanity or autonomy.
- Preserve and expose `publicValue` through normalization utilities and display it in the result card UI.

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a7117b206c83308e184c5044dccb94