### PR TITLE
feat: add GA4 with consent mode

### DIFF
--- a/Leerdoelengenerator-main/index.html
+++ b/Leerdoelengenerator-main/index.html
@@ -7,6 +7,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Leerdoelenmaker | DigitEd</title>
     <meta name="description" content="Eenvoudige tool voor docenten om traditionele leerdoelen om te vormen naar AI-ready versies volgens de Nederlandse visie op AI-bewust onderwijs." />
+    <!-- Consent Mode: standaard denied -->
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('consent', 'default', {
+        ad_storage: 'denied',
+        analytics_storage: 'denied',
+        functionality_storage: 'denied',
+        security_storage: 'granted'
+      });
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J1Q1DZ40PB"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/Leerdoelengenerator-main/package.json
+++ b/Leerdoelengenerator-main/package.json
@@ -18,7 +18,8 @@
     "docx": "^8.5.0",
     "file-saver": "^2.0.5",
     "@google/generative-ai": "^0.2.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "react-router-dom": "^6.24.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/Leerdoelengenerator-main/src/components/CookieBanner.tsx
+++ b/Leerdoelengenerator-main/src/components/CookieBanner.tsx
@@ -1,59 +1,54 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react';
+import { updateConsent } from '@/lib/ga';
 
-const KEY = 'cookie-consent-v1'
+const KEY = 'cookie-consent-v1';
 
 export default function CookieBanner() {
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    const saved = localStorage.getItem(KEY)
-    if (!saved) setOpen(true)
-  }, [])
+    const saved = localStorage.getItem(KEY);
+    if (!saved) {
+      setOpen(true);
+    } else {
+      updateConsent(saved === 'granted');
+    }
+  }, []);
 
   const grant = () => {
-    localStorage.setItem(KEY, 'granted')
-    ;(window as any).gtag?.('consent', 'update', {
-      analytics_storage: 'granted',
-      functionality_storage: 'granted',
-    })
-
-    // Eerste page_view direct na akkoord
-    const id = import.meta.env.VITE_GA_ID as string | undefined
-    const isProd = import.meta.env.PROD
-
-    if (isProd && id) {
-      ;(window as any).gtag?.('event', 'page_view', {
-        page_location: window.location.href,
-        page_title: document.title,
-      })
-    }
-
-    setOpen(false)
-  }
+    localStorage.setItem(KEY, 'granted');
+    updateConsent(true);
+    setOpen(false);
+  };
 
   const deny = () => {
-    localStorage.setItem(KEY, 'denied')
-    setOpen(false)
-  }
+    localStorage.setItem(KEY, 'denied');
+    updateConsent(false);
+    setOpen(false);
+  };
 
-  if (!open) return null
+  if (!open) return null;
 
   return (
-    <div style={{
-      position:'fixed', left:0, right:0, bottom:0, zIndex:9999,
-      padding:'12px 16px', background:'#111', color:'#fff',
-      display:'flex', gap:12, alignItems:'center', flexWrap:'wrap'
-    }}>
-      <span>
-        We gebruiken analytische cookies om bezoek te meten. Akkoord?
-        <a href="/privacy" style={{marginLeft:8, color:'#9cf', textDecoration:'underline'}}>
-          Privacyverklaring
-        </a>
-      </span>
-      <div style={{marginLeft:'auto', display:'flex', gap:8}}>
-        <button onClick={deny}>Weigeren</button>
-        <button onClick={grant}>Akkoord</button>
-      </div>
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 16,
+        left: 16,
+        right: 16,
+        background: '#111',
+        color: '#fff',
+        padding: 16,
+        borderRadius: 8,
+      }}
+    >
+      <span>We gebruiken cookies voor anonieme analytics. Akkoord?</span>
+      <button onClick={deny} style={{ marginLeft: 8 }}>
+        Weigeren
+      </button>
+      <button onClick={grant} style={{ marginLeft: 8 }}>
+        Akkoord
+      </button>
     </div>
-  )
+  );
 }

--- a/Leerdoelengenerator-main/src/components/RouteTracker.tsx
+++ b/Leerdoelengenerator-main/src/components/RouteTracker.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { trackPage } from '@/lib/ga';
+
+export default function RouteTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (localStorage.getItem('cookie-consent-v1') === 'granted') {
+      trackPage(location.pathname, document.title);
+    }
+  }, [location]);
+
+  return null;
+}

--- a/Leerdoelengenerator-main/src/lib/ga.ts
+++ b/Leerdoelengenerator-main/src/lib/ga.ts
@@ -1,0 +1,34 @@
+const GA_ID = 'G-J1Q1DZ40PB';
+
+export function updateConsent(granted: boolean) {
+  const gtag = (window as any).gtag;
+  if (!gtag) return;
+
+  gtag('consent', 'update', {
+    analytics_storage: granted ? 'granted' : 'denied',
+    functionality_storage: granted ? 'granted' : 'denied',
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+    security_storage: 'granted',
+  });
+
+  if (granted) {
+    gtag('config', GA_ID, { anonymize_ip: true });
+    gtag('event', 'page_view', {
+      page_path: window.location.pathname,
+      page_title: document.title,
+      page_location: window.location.href,
+    });
+  }
+}
+
+export function trackPage(path: string, title?: string) {
+  const gtag = (window as any).gtag;
+  if (!gtag) return;
+  gtag('event', 'page_view', {
+    page_path: path,
+    page_title: title ?? document.title,
+    page_location: window.location.href,
+  });
+}

--- a/Leerdoelengenerator-main/src/main.tsx
+++ b/Leerdoelengenerator-main/src/main.tsx
@@ -1,59 +1,22 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import HomePage from './pages/index.tsx';
 import About from './pages/About.tsx';
 import Layout from './components/Layout.tsx';
+import RouteTracker from './components/RouteTracker.tsx';
 import './index.css';
-
-function loadGA(measurementId: string) {
-  // 1) load gtag.js
-  const s = document.createElement('script');
-  s.async = true;
-  s.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
-  document.head.appendChild(s);
-
-  // 2) dataLayer + gtag helper
-  (window as any).dataLayer = (window as any).dataLayer || [];
-  function gtag(...args: any[]) {
-    (window as any).dataLayer.push(args);
-  }
-  (window as any).gtag = gtag;
-
-  // 3) Consent Mode v2 - default denied
-  gtag('consent', 'default', {
-    ad_storage: 'denied',
-    ad_user_data: 'denied',
-    ad_personalization: 'denied',
-    analytics_storage: 'denied',
-    functionality_storage: 'denied',
-  });
-
-  // 4) basic config (no page_view yet!)
-  gtag('js', new Date());
-  gtag('config', measurementId, {
-    anonymize_ip: true,
-    send_page_view: false,
-  });
-}
-
-if (import.meta.env.PROD && import.meta.env.VITE_GA_ID) {
-  loadGA(import.meta.env.VITE_GA_ID);
-}
 
 const rootElement = document.getElementById('root')!;
 
-function Router() {
-  const path = window.location.pathname;
-  const Page = path === '/over' ? About : HomePage;
-  return (
-    <Layout>
-      <Page />
-    </Layout>
-  );
-}
-
 createRoot(rootElement).render(
   <StrictMode>
-    <Router />
+    <BrowserRouter>
+      <RouteTracker />
+      <Routes>
+        <Route path="/" element={<Layout><HomePage /></Layout>} />
+        <Route path="/over" element={<Layout><About /></Layout>} />
+      </Routes>
+    </BrowserRouter>
   </StrictMode>
 );

--- a/Leerdoelengenerator-main/tsconfig.app.json
+++ b/Leerdoelengenerator-main/tsconfig.app.json
@@ -13,6 +13,10 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/Leerdoelengenerator-main/vite.config.ts
+++ b/Leerdoelengenerator-main/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -7,5 +8,10 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
-  define: { global: 'globalThis', 'process.env': {} }
+  define: { global: 'globalThis', 'process.env': {} },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- integrate GA4 Consent Mode scripts into index.html
- add GA helper utilities and cookie banner consent handling
- track route changes and configure router with React Router

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a72e9e9fa883309fbe14313ca83c9b