### PR TITLE
Implement GA4 consent mode with cookie banner and route tracking

### DIFF
--- a/Leerdoelengenerator-main/index.html
+++ b/Leerdoelengenerator-main/index.html
@@ -7,20 +7,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Leerdoelenmaker | DigitEd</title>
     <meta name="description" content="Eenvoudige tool voor docenten om traditionele leerdoelen om te vormen naar AI-ready versies volgens de Nederlandse visie op AI-bewust onderwijs." />
-    <!-- Consent Mode: standaard denied -->
+    <!-- Consent Mode v2: eerst default = denied, vóór het laden van gtag.js -->
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
+      function gtag(){ dataLayer.push(arguments); }
+      // Timestamp
       gtag('js', new Date());
+      // Alles denied tot akkoord (cookieless pings mogelijk)
       gtag('consent', 'default', {
         ad_storage: 'denied',
         analytics_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
         functionality_storage: 'denied',
         security_storage: 'granted'
       });
     </script>
+
+    <!-- Laad GA4 bibliotheek met jouw meet-ID (nodig voor detectie door GA UI) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J1Q1DZ40PB"></script>
   </head>
   <body>

--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -29,7 +29,6 @@ import { getVoGradeOptions } from "./utils/vo";
 import { LevelBadge } from "./components/LevelBadge";
 import { NiveauCheck } from "./components/NiveauCheck";
 import { LevelKey } from "./domain/levelProfiles";
-import CookieBanner from "./components/CookieBanner";
 
 /* --------------------- Helpers: opslag + delen --------------------- */
 const STORAGE_KEY = "ld-app-state-v2";
@@ -690,7 +689,6 @@ function App() {
 
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-green-50 via-white to-orange-50">
-      <CookieBanner />
       {/* Header */}
       <header className="bg-white shadow-sm border-b border-green-100">
         <div className="max-w-screen-xl mx-auto px-4 lg:px-8 py-4">

--- a/Leerdoelengenerator-main/src/components/CookieBanner.tsx
+++ b/Leerdoelengenerator-main/src/components/CookieBanner.tsx
@@ -1,5 +1,12 @@
+// src/components/CookieBanner.tsx
 import { useEffect, useState } from 'react';
-import { updateConsent } from '@/lib/ga';
+import {
+  initGA,
+  sendMinimalPageView,
+  sendEnhancedPageView,
+  updateConsentGranted,
+  updateConsentDenied,
+} from '@/lib/ga';
 
 const KEY = 'cookie-consent-v1';
 
@@ -7,46 +14,53 @@ export default function CookieBanner() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
+    // Init GA-config
+    initGA();
+
     const saved = localStorage.getItem(KEY);
     if (!saved) {
       setOpen(true);
+      // Altijd minimale page_view op eerste bezoek (cookieless)
+      sendMinimalPageView();
+    } else if (saved === 'granted') {
+      updateConsentGranted().then(() => sendEnhancedPageView());
     } else {
-      updateConsent(saved === 'granted');
+      updateConsentDenied().then(() => sendMinimalPageView());
     }
   }, []);
 
-  const grant = () => {
+  const grant = async () => {
     localStorage.setItem(KEY, 'granted');
-    updateConsent(true);
+    await updateConsentGranted();
     setOpen(false);
+    // Direct enhanced page_view na akkoord
+    await sendEnhancedPageView();
   };
 
-  const deny = () => {
+  const deny = async () => {
     localStorage.setItem(KEY, 'denied');
-    updateConsent(false);
+    await updateConsentDenied();
     setOpen(false);
+    // Optioneel nogmaals minimal bevestigen
+    await sendMinimalPageView();
   };
 
   if (!open) return null;
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        bottom: 16,
-        left: 16,
-        right: 16,
-        background: '#111',
-        color: '#fff',
-        padding: 16,
-        borderRadius: 8,
-      }}
-    >
-      <span>We gebruiken cookies voor anonieme analytics. Akkoord?</span>
-      <button onClick={deny} style={{ marginLeft: 8 }}>
+    <div style={{
+      position: 'fixed', inset: 'auto 16px 16px 16px',
+      background: '#111', color: '#fff', padding: '12px 16px',
+      borderRadius: 8, zIndex: 9999, display: 'flex', gap: 8, alignItems: 'center',
+      boxShadow: '0 6px 32px rgba(0,0,0,.35)'
+    }}>
+      <div style={{ flex: 1 }}>
+        We gebruiken cookies voor anonieme analytics. Akkoord voor volledige meting?
+      </div>
+      <button onClick={deny} style={{ background: 'transparent', color: '#fff', border: '1px solid #fff', borderRadius: 6, padding: '8px 12px' }}>
         Weigeren
       </button>
-      <button onClick={grant} style={{ marginLeft: 8 }}>
+      <button onClick={grant} style={{ background: '#4ade80', color: '#111', border: 'none', borderRadius: 6, padding: '8px 12px', fontWeight: 600 }}>
         Akkoord
       </button>
     </div>

--- a/Leerdoelengenerator-main/src/components/RouteTracker.tsx
+++ b/Leerdoelengenerator-main/src/components/RouteTracker.tsx
@@ -1,13 +1,17 @@
+// src/components/RouteTracker.tsx
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { trackPage } from '@/lib/ga';
+import { sendMinimalPageView, sendEnhancedPageView } from '@/lib/ga';
 
 export default function RouteTracker() {
   const location = useLocation();
 
   useEffect(() => {
-    if (localStorage.getItem('cookie-consent-v1') === 'granted') {
-      trackPage(location.pathname, document.title);
+    const consent = localStorage.getItem('cookie-consent-v1');
+    if (consent === 'granted') {
+      sendEnhancedPageView(location.pathname, document.title);
+    } else {
+      sendMinimalPageView(location.pathname, document.title);
     }
   }, [location]);
 

--- a/Leerdoelengenerator-main/src/lib/ga.ts
+++ b/Leerdoelengenerator-main/src/lib/ga.ts
@@ -1,34 +1,94 @@
+// src/lib/ga.ts
 const GA_ID = 'G-J1Q1DZ40PB';
 
-export function updateConsent(granted: boolean) {
-  const gtag = (window as any).gtag;
+function g() {
+  return (window as any).gtag as undefined | ((...args: any[]) => void);
+}
+
+async function gtagReady(timeoutMs = 5000) {
+  const start = performance.now();
+  while (performance.now() - start < timeoutMs) {
+    if (typeof g() === 'function') return;
+    await new Promise(r => setTimeout(r, 50));
+  }
+}
+
+/** Initialiseer GA4 config zonder automatische page_view */
+export async function initGA() {
+  await gtagReady();
+  const gtag = g();
+  if (!gtag) return;
+
+  gtag('config', GA_ID, {
+    anonymize_ip: true,
+    send_page_view: false,              // wij sturen page_views zelf (minimaal/enhanced)
+    allow_google_signals: false,
+    allow_ad_personalization_signals: false,
+  });
+}
+
+/** Minimale page_view – werkt ook bij consent = denied (cookieless ping) */
+export async function sendMinimalPageView(
+  path = window.location.pathname,
+  title = document.title
+) {
+  await gtagReady();
+  const gtag = g();
+  if (!gtag) return;
+
+  gtag('event', 'page_view', {
+    page_path: path,
+    page_title: title,
+    page_location: window.location.href,
+    send_to: GA_ID,
+  });
+}
+
+/** Volwaardige page_view – gebruiken na consent = granted */
+export async function sendEnhancedPageView(
+  path = window.location.pathname,
+  title = document.title
+) {
+  await gtagReady();
+  const gtag = g();
+  if (!gtag) return;
+
+  gtag('event', 'page_view', {
+    page_path: path,
+    page_title: title,
+    page_location: window.location.href,
+    send_to: GA_ID,
+  });
+}
+
+/** Consent → granted (alleen analytics/functionality; ads blijven uit) */
+export async function updateConsentGranted() {
+  await gtagReady();
+  const gtag = g();
   if (!gtag) return;
 
   gtag('consent', 'update', {
-    analytics_storage: granted ? 'granted' : 'denied',
-    functionality_storage: granted ? 'granted' : 'denied',
+    analytics_storage: 'granted',
+    functionality_storage: 'granted',
     ad_storage: 'denied',
     ad_user_data: 'denied',
     ad_personalization: 'denied',
     security_storage: 'granted',
   });
-
-  if (granted) {
-    gtag('config', GA_ID, { anonymize_ip: true });
-    gtag('event', 'page_view', {
-      page_path: window.location.pathname,
-      page_title: document.title,
-      page_location: window.location.href,
-    });
-  }
 }
 
-export function trackPage(path: string, title?: string) {
-  const gtag = (window as any).gtag;
+/** Consent → denied */
+export async function updateConsentDenied() {
+  await gtagReady();
+  const gtag = g();
   if (!gtag) return;
-  gtag('event', 'page_view', {
-    page_path: path,
-    page_title: title ?? document.title,
-    page_location: window.location.href,
+
+  gtag('consent', 'update', {
+    analytics_storage: 'denied',
+    functionality_storage: 'denied',
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+    security_storage: 'granted',
   });
 }

--- a/Leerdoelengenerator-main/src/main.tsx
+++ b/Leerdoelengenerator-main/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import HomePage from './pages/index.tsx';
-import About from './pages/About.tsx';
-import Layout from './components/Layout.tsx';
-import RouteTracker from './components/RouteTracker.tsx';
+import HomePage from '@/pages/index';
+import About from '@/pages/About';
+import Layout from '@/components/Layout';
+import RouteTracker from '@/components/RouteTracker';
+import CookieBanner from '@/components/CookieBanner';
 import './index.css';
 
 const rootElement = document.getElementById('root')!;
@@ -17,6 +18,7 @@ createRoot(rootElement).render(
         <Route path="/" element={<Layout><HomePage /></Layout>} />
         <Route path="/over" element={<Layout><About /></Layout>} />
       </Routes>
+      <CookieBanner />
     </BrowserRouter>
   </StrictMode>
 );

--- a/Leerdoelengenerator-main/tsconfig.json
+++ b/Leerdoelengenerator-main/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
## Summary
- load GA4 with Consent Mode v2 default denied and no automatic config
- add GA helper to init, send minimal/enhanced pageviews and manage consent
- render cookie banner and route tracker to send pageviews on route changes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a73ff5037083308e1fc3b7300348f4