### PR TITLE
Add GA consent mode and SPA tracking

### DIFF
--- a/Leerdoelengenerator-main/index.html
+++ b/Leerdoelengenerator-main/index.html
@@ -1,19 +1,14 @@
 <!doctype html>
 <html lang="nl">
   <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Leerdoelenmaker | DigitEd</title>
-    <meta name="description" content="Eenvoudige tool voor docenten om traditionele leerdoelen om te vormen naar AI-ready versies volgens de Nederlandse visie op AI-bewust onderwijs." />
-    <!-- Consent Mode v2: eerst default = denied, vóór het laden van gtag.js -->
+    <!-- Google tag (gtag.js) — direct na <head>, precies één keer -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J1Q1DZ40PB"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){ dataLayer.push(arguments); }
-      // Timestamp
+
+      // Consent Mode v2: standaard alles denied (cookieless pings toegestaan)
       gtag('js', new Date());
-      // Alles denied tot akkoord (cookieless pings mogelijk)
       gtag('consent', 'default', {
         ad_storage: 'denied',
         analytics_storage: 'denied',
@@ -22,10 +17,23 @@
         functionality_storage: 'denied',
         security_storage: 'granted'
       });
+
+      // Eén centrale config (geen extra config-calls elders)
+      // We zetten send_page_view op false zodat wij zelf pageviews sturen (init + routewissels)
+      gtag('config', 'G-J1Q1DZ40PB', {
+        send_page_view: false,
+        anonymize_ip: true,
+        allow_google_signals: false,
+        allow_ad_personalization_signals: false
+      });
     </script>
 
-    <!-- Laad GA4 bibliotheek met jouw meet-ID (nodig voor detectie door GA UI) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J1Q1DZ40PB"></script>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Leerdoelenmaker | DigitEd</title>
+    <meta name="description" content="Eenvoudige tool voor docenten om traditionele leerdoelen om te vormen naar AI-ready versies volgens de Nederlandse visie op AI-bewust onderwijs." />
   </head>
   <body>
     <div id="root"></div>

--- a/Leerdoelengenerator-main/src/components/CookieBanner.tsx
+++ b/Leerdoelengenerator-main/src/components/CookieBanner.tsx
@@ -1,12 +1,5 @@
-// src/components/CookieBanner.tsx
 import { useEffect, useState } from 'react';
-import {
-  initGA,
-  sendMinimalPageView,
-  sendEnhancedPageView,
-  updateConsentGranted,
-  updateConsentDenied,
-} from '@/lib/ga';
+import { sendPageView, setConsentGranted, setConsentDenied } from '@/lib/ga';
 
 const KEY = 'cookie-consent-v1';
 
@@ -14,35 +7,31 @@ export default function CookieBanner() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    // Init GA-config
-    initGA();
-
     const saved = localStorage.getItem(KEY);
+
     if (!saved) {
+      // Eerste bezoek → toon banner en stuur een cookieless page_view
       setOpen(true);
-      // Altijd minimale page_view op eerste bezoek (cookieless)
-      sendMinimalPageView();
+      sendPageView(); // cookieless door consent=denied
     } else if (saved === 'granted') {
-      updateConsentGranted().then(() => sendEnhancedPageView());
+      setConsentGranted().then(() => sendPageView());
     } else {
-      updateConsentDenied().then(() => sendMinimalPageView());
+      setConsentDenied().then(() => sendPageView()); // cookieless bevestiging
     }
   }, []);
 
   const grant = async () => {
     localStorage.setItem(KEY, 'granted');
-    await updateConsentGranted();
+    await setConsentGranted();
     setOpen(false);
-    // Direct enhanced page_view na akkoord
-    await sendEnhancedPageView();
+    await sendPageView(); // enhanced page_view na akkoord
   };
 
   const deny = async () => {
     localStorage.setItem(KEY, 'denied');
-    await updateConsentDenied();
+    await setConsentDenied();
     setOpen(false);
-    // Optioneel nogmaals minimal bevestigen
-    await sendMinimalPageView();
+    await sendPageView(); // blijft cookieless
   };
 
   if (!open) return null;

--- a/Leerdoelengenerator-main/src/components/RouteTracker.tsx
+++ b/Leerdoelengenerator-main/src/components/RouteTracker.tsx
@@ -1,18 +1,13 @@
-// src/components/RouteTracker.tsx
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { sendMinimalPageView, sendEnhancedPageView } from '@/lib/ga';
+import { sendPageView } from '@/lib/ga';
 
 export default function RouteTracker() {
   const location = useLocation();
 
   useEffect(() => {
-    const consent = localStorage.getItem('cookie-consent-v1');
-    if (consent === 'granted') {
-      sendEnhancedPageView(location.pathname, document.title);
-    } else {
-      sendMinimalPageView(location.pathname, document.title);
-    }
+    // Consent-status bepaalt vanzelf of dit cookieless of enhanced is
+    sendPageView(location.pathname, document.title);
   }, [location]);
 
   return null;

--- a/Leerdoelengenerator-main/src/lib/ga.ts
+++ b/Leerdoelengenerator-main/src/lib/ga.ts
@@ -1,4 +1,3 @@
-// src/lib/ga.ts
 const GA_ID = 'G-J1Q1DZ40PB';
 
 function g() {
@@ -13,22 +12,8 @@ async function gtagReady(timeoutMs = 5000) {
   }
 }
 
-/** Initialiseer GA4 config zonder automatische page_view */
-export async function initGA() {
-  await gtagReady();
-  const gtag = g();
-  if (!gtag) return;
-
-  gtag('config', GA_ID, {
-    anonymize_ip: true,
-    send_page_view: false,              // wij sturen page_views zelf (minimaal/enhanced)
-    allow_google_signals: false,
-    allow_ad_personalization_signals: false,
-  });
-}
-
-/** Minimale page_view – werkt ook bij consent = denied (cookieless ping) */
-export async function sendMinimalPageView(
+/** Stuur een page_view (cookieless als consent denied is) */
+export async function sendPageView(
   path = window.location.pathname,
   title = document.title
 ) {
@@ -44,25 +29,8 @@ export async function sendMinimalPageView(
   });
 }
 
-/** Volwaardige page_view – gebruiken na consent = granted */
-export async function sendEnhancedPageView(
-  path = window.location.pathname,
-  title = document.title
-) {
-  await gtagReady();
-  const gtag = g();
-  if (!gtag) return;
-
-  gtag('event', 'page_view', {
-    page_path: path,
-    page_title: title,
-    page_location: window.location.href,
-    send_to: GA_ID,
-  });
-}
-
-/** Consent → granted (alleen analytics/functionality; ads blijven uit) */
-export async function updateConsentGranted() {
+/** Consent → granted (analytics + functionality) */
+export async function setConsentGranted() {
   await gtagReady();
   const gtag = g();
   if (!gtag) return;
@@ -73,12 +41,12 @@ export async function updateConsentGranted() {
     ad_storage: 'denied',
     ad_user_data: 'denied',
     ad_personalization: 'denied',
-    security_storage: 'granted',
+    security_storage: 'granted'
   });
 }
 
 /** Consent → denied */
-export async function updateConsentDenied() {
+export async function setConsentDenied() {
   await gtagReady();
   const gtag = g();
   if (!gtag) return;
@@ -89,6 +57,6 @@ export async function updateConsentDenied() {
     ad_storage: 'denied',
     ad_user_data: 'denied',
     ad_personalization: 'denied',
-    security_storage: 'granted',
+    security_storage: 'granted'
   });
 }


### PR DESCRIPTION
## Summary
- add single GA tag with consent mode and config in `index.html`
- track analytics via helper functions and CookieBanner consent
- send page views on SPA route changes

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a745008dac83309fffd7cfd64b7d3c