### PR TITLE
feat: suggest activities and assessments for goals

### DIFF
--- a/Leerdoelengenerator-main/src/components/Suggestions.tsx
+++ b/Leerdoelengenerator-main/src/components/Suggestions.tsx
@@ -1,0 +1,58 @@
+import { SuggestionBundle } from '@/types/learning';
+
+export default function Suggestions({ data }: { data: SuggestionBundle }) {
+  if (!data) return null;
+
+  const copyActivities = () => {
+    const text = data.activities
+      .map(a => `${a.title} - ${a.description}${a.duration ? ` (${a.duration})` : ''} (${a.why})`)
+      .join('\n');
+    navigator.clipboard.writeText(text);
+  };
+
+  const copyAssessments = () => {
+    const text = data.assessments
+      .map(t => `${t.title} - ${t.description} (${t.why})`)
+      .join('\n');
+    navigator.clipboard.writeText(text);
+  };
+
+  return (
+    <section className="mt-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Aanbevolen activiteiten</h3>
+        <button onClick={copyActivities} className="text-xs text-blue-600">Kopieer</button>
+      </div>
+      <ul className="list-disc pl-5 space-y-2">
+        {data.activities.map((a, i) => (
+          <li key={i}>
+            <div className="font-medium flex items-center">
+              {a.title}
+              <span className="ml-2 text-xs text-gray-500" title={a.why}>i</span>
+            </div>
+            <div className="text-sm opacity-80">{a.description}{a.duration ? ` · ${a.duration}` : ''}</div>
+            <div className="text-xs opacity-70 italic">Waarom: {a.why}</div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex items-center justify-between mt-6">
+        <h3 className="text-lg font-semibold">Mogelijke toetsvormen</h3>
+        <button onClick={copyAssessments} className="text-xs text-blue-600">Kopieer</button>
+      </div>
+      <ul className="list-disc pl-5 space-y-2">
+        {data.assessments.map((t, i) => (
+          <li key={i}>
+            <div className="font-medium flex items-center">
+              {t.title}
+              <span className="ml-2 text-xs text-gray-500" title={t.why}>i</span>
+            </div>
+            <div className="text-sm opacity-80">{t.description}</div>
+            <div className="text-xs opacity-70 italic">Waarom: {t.why}</div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+

--- a/Leerdoelengenerator-main/src/data/suggestions.ts
+++ b/Leerdoelengenerator-main/src/data/suggestions.ts
@@ -1,0 +1,140 @@
+import { EducationLevel, GoalOrientation, SuggestionBundle } from '@/types/learning';
+
+type Key = `${GoalOrientation}:${EducationLevel}`;
+const base: Record<Key, SuggestionBundle> = {
+  'kennis:MBO-3': {
+    activities: [
+      { title: '3–2–1 uitleg', description: 'Student noteert 3 kernbegrippen, 2 verbanden, 1 vraag en bespreekt die in duo’s.', duration: '20 min', why: 'Activeert voorkennis en begrip (kennisdoel).' },
+      { title: 'Mini-lecture met check', description: 'Korte instructie gevolgd door 5 conceptvragen via Mentimeter/Forms.', duration: '25 min', why: 'Snelle formatieve check op kennisopbouw.' },
+    ],
+    assessments: [
+      { title: 'Kennisquiz (open/gesloten)', description: 'Korte quiz met feedback, herkansbaar.', formative: true, why: 'Passend bij kennisdoelen; directe feedback.' }
+    ]
+  },
+  'vaardigheid:MBO-4': {
+    activities: [
+      { title: 'Simulatie/rolspel', description: 'Oefen beroepshandeling in tweetallen met observatielijst.', duration: '45 min', why: 'Transfer naar beroepspraktijk (vaardigheidsdoel).' },
+      { title: 'Stap-voor-stap demonstratie', description: 'Docent modelt handeling; studenten herhalen met peerfeedback.', duration: '40 min', why: 'Scaffolding en geleidelijke zelfstandigheid.' },
+    ],
+    assessments: [
+      { title: 'Praktijkopdracht met rubric', description: 'Uitvoering van handeling met beoordelingscriteria.', summative: true, why: 'Observeerbare vaardigheid; valide beoordeling.' }
+    ]
+  },
+  'attitude:MBO-2': {
+    activities: [
+      { title: 'Reflectie-drieluik', description: 'Wat ging goed? Wat beter? Volgende stap? Deel in kleine kring.', duration: '20 min', why: 'Maakt houding zichtbaar via reflectie.' },
+      { title: 'Feedback-carrousel', description: 'Studenten geven elkaar waarderende feedback met 2 verbeterpunten.', duration: '25 min', why: 'Stimuleert professionele attitude en peer-leren.' },
+    ],
+    assessments: [
+      { title: 'Reflectieverslag met bewijs', description: 'Korte reflectie met concrete voorbeelden en bewijsstukken.', formative: true, why: 'Attitude borg je via onderbouwde reflectie.' }
+    ]
+  },
+  'kennis:VO-vwo': {
+    activities: [
+      { title: 'Concept mapping', description: 'Leerlingen leggen verbanden tussen begrippen in een schema.', duration: '30 min', why: 'Verdiept begrip door relaties te visualiseren.' },
+      { title: 'Flitscollege', description: 'Docent geeft korte uitleg gevolgd door begripstoets via Kahoot.', duration: '20 min', why: 'Houdt aandacht vast en checkt kennis direct.' },
+    ],
+    assessments: [
+      { title: 'Formatieve proef', description: 'Korte toets met bespreking in tweetallen.', formative: true, why: 'Biedt inzicht in begripsniveau.' }
+    ]
+  },
+  'vaardigheid:HBO-ba': {
+    activities: [
+      { title: 'Case-based project', description: 'Werk in groepjes aan realistische casus met oplevering.', duration: '2 uur', why: 'Oefent beroepsvaardigheden in context.' },
+      { title: 'Workshop met expert', description: 'Gastspreker demonstreert techniek; studenten oefenen direct.', duration: '90 min', why: 'Combineert theorie en praktijk.' },
+    ],
+    assessments: [
+      { title: 'Praktijkproduct met peerreview', description: 'Ingeleverd product met feedback van medestudenten.', summative: true, why: 'Beoordeling op toepassen van vaardigheden.' }
+    ]
+  },
+  'kennis:HBO-ma': {
+    activities: [
+      { title: 'Literatuurkritiek', description: 'Analyseer recent onderzoek en bespreek implicaties.', duration: '60 min', why: 'Versterkt onderzoeksgerichte kennis.' },
+      { title: 'Expertpanel', description: 'Studenten bevragen vakexperts over complexe theorie.', duration: '45 min', why: 'Verbindt theorie met praktijkervaring.' },
+    ],
+    assessments: [
+      { title: 'Essay met peerfeedback', description: 'Kritische beschouwing van theorie toegepast op casus.', summative: true, why: 'Toetst diep begrip en argumentatie.' }
+    ]
+  },
+  'vaardigheid:VO-vmbo': {
+    activities: [
+      { title: 'Praktijksessie', description: 'Leerlingen voeren stap-voor-stap taak uit in praktijklokaal.', duration: '40 min', why: 'Hands-on leren past bij vmbo-leerlingen.' },
+      { title: 'Begeleide oefening', description: 'Docent ondersteunt bij uitvoeren van vaardigheidsoefening.', duration: '30 min', why: 'Biedt structuur en vertrouwen.' },
+    ],
+    assessments: [
+      { title: 'Praktijkobservatie', description: 'Docent observeert uitvoering met checklist.', formative: true, why: 'Directe feedback op vaardigheid.' }
+    ]
+  },
+  'attitude:VO-havo': {
+    activities: [
+      { title: 'Debat over stelling', description: 'Leerlingen nemen positie in en beargumenteren.', duration: '30 min', why: 'Stimuleert kritische houding en respect.' },
+      { title: 'Reflectieblog', description: 'Wekelijkse blog over eigen leerhouding.', duration: '20 min', why: 'Maakt ontwikkeling zichtbaar.' },
+    ],
+    assessments: [
+      { title: 'Zelfevaluatieformulier', description: 'Leerling beoordeelt eigen inzet en groeipunten.', formative: true, why: 'Bevordert eigenaarschap van houding.' }
+    ]
+  },
+  'kennis:WO-ba': {
+    activities: [
+      { title: 'Collegediscussie', description: 'Bespreek theorie in kleine groepen met stellingen.', duration: '30 min', why: 'Actieve verwerking van academische kennis.' },
+      { title: 'Quiz met stembakjes', description: 'Meerkeuzevragen tijdens hoorcollege.', duration: '15 min', why: 'Real-time inzicht in kennisniveau.' },
+    ],
+    assessments: [
+      { title: 'Korte paper', description: 'Analyse van theoretisch concept toegepast op casus.', summative: true, why: 'Toetst begrip en schrijfvaardigheid.' }
+    ]
+  },
+  'vaardigheid:WO-ma': {
+    activities: [
+      { title: 'Onderzoeksatelier', description: 'Werk aan eigen onderzoek met begeleiding.', duration: '120 min', why: 'Ontwikkelt onderzoeksvaardigheden.' },
+      { title: 'Peer coaching', description: 'Studenten geven elkaar feedback op methodologie.', duration: '45 min', why: 'Verbetert kwaliteit door collegiale toetsing.' },
+    ],
+    assessments: [
+      { title: 'Onderzoeksverslag', description: 'Volledig verslag inclusief methodologische verantwoording.', summative: true, why: 'Beoordeelt toegepaste onderzoeksvaardigheden.' }
+    ]
+  },
+  'attitude:VSO-vervolg': {
+    activities: [
+      { title: 'Samenwerkingsspel', description: 'Leerlingen lossen in groep een praktische uitdaging op.', duration: '30 min', why: 'Oefent sociale vaardigheden en houding.' },
+      { title: 'Dagreflectie', description: 'Kort kringgesprek over wat goed ging en wat lastig was.', duration: '15 min', why: 'Vergroot zelfinzicht en respect.' },
+    ],
+    assessments: [
+      { title: 'Portfolio-moment', description: 'Verzamel bewijs van samenwerking en reflectie.', formative: true, why: 'Laat groei in houding zien over tijd.' }
+    ]
+  },
+  'kennis:VSO-arbeidsmarkt': {
+    activities: [
+      { title: 'Beroepenmemory', description: 'Leerlingen koppelen beroepen aan taken en eigenschappen.', duration: '25 min', why: 'Vergroot kennis van arbeidsmogelijkheden.' },
+      { title: 'Gastles werkgever', description: 'Werkgever vertelt over vak; leerlingen stellen vragen.', duration: '30 min', why: 'Concretiseert arbeidsmarkt voor leerlingen.' },
+    ],
+    assessments: [
+      { title: 'Mondelinge check', description: 'Korte vragenronde over beroepen en taken.', formative: true, why: 'Peilt begripsniveau informeel.' }
+    ]
+  },
+  'vaardigheid:MBO-1': {
+    activities: [
+      { title: 'Stap-voor-stap instructie', description: 'Docent doet voor, student doet na met begeleiding.', duration: '30 min', why: 'Bouwt basisvaardigheid veilig op.' },
+      { title: 'Klassikale oefening', description: 'Samen oefenen met directe feedback.', duration: '20 min', why: 'Versterkt correct uitvoeren van stappen.' },
+    ],
+    assessments: [
+      { title: 'Beoordelingsgesprek', description: 'Korte evaluatie van uitgevoerde handeling.', formative: true, why: 'Stimuleert groei vanaf startniveau.' }
+    ]
+  }
+};
+
+export function getSuggestions(
+  orientation: GoalOrientation,
+  level: EducationLevel
+): SuggestionBundle {
+  const key = `${orientation}:${level}` as Key;
+  if (base[key]) return base[key];
+  const generic: SuggestionBundle = {
+    activities: [
+      { title: 'Think-Pair-Share', description: 'Eerst individueel, dan duo, dan klassikaal delen.', why: 'Generiek inzetbaar en activerend.' }
+    ],
+    assessments: [
+      { title: 'Korte formatieve check', description: '3–5 vragen met feedback.', formative: true, why: 'Lage drempel, snel beeld.' }
+    ]
+  };
+  return generic;
+}
+

--- a/Leerdoelengenerator-main/src/lib/format.ts
+++ b/Leerdoelengenerator-main/src/lib/format.ts
@@ -1,4 +1,5 @@
 import { normalizeObjective } from "./nlGoals";
+import type { SuggestionBundle } from "@/types/learning";
 
 export interface SMARTCheck {
   badge: "✅" | "❌";
@@ -15,6 +16,7 @@ export interface PostProcessedResponse {
   aiLiteracyFocus: string[];
   smart: SMARTCheck;
   warnings: string[];
+  suggestions?: SuggestionBundle;
 }
 
 /**

--- a/Leerdoelengenerator-main/src/services/llm.ts
+++ b/Leerdoelengenerator-main/src/services/llm.ts
@@ -2,6 +2,8 @@ import type { KDContext, GeminiResponse } from "./gemini";
 import type { LearningObjectiveContext } from "../types/context";
 import { geminiService } from "./gemini";
 import { enforceDutchAndSMART, PostProcessedResponse } from "../lib/format";
+import { getSuggestions } from "@/data/suggestions";
+import { inferGoalOrientation, mapEducationLevel } from "@/utils/suggestionHelpers";
 
 /**
  * Probeer eenvoudige JSON-fouten te herstellen. Strip bijvoorbeeld
@@ -87,6 +89,9 @@ export async function generateNormalizedObjective(
     processed.assessments = processed.assessments.map(repl);
     processed.aiLiteracy = repl(processed.aiLiteracy);
   }
+  const orientation = inferGoalOrientation(processed.newObjective);
+  const level = mapEducationLevel(ctx);
+  processed.suggestions = getSuggestions(orientation, level);
   return processed;
 }
 

--- a/Leerdoelengenerator-main/src/types/learning.ts
+++ b/Leerdoelengenerator-main/src/types/learning.ts
@@ -1,0 +1,37 @@
+export type GoalOrientation = 'kennis' | 'vaardigheid' | 'attitude';
+export type EducationLevel =
+  | 'VO-vmbo'
+  | 'VO-havo'
+  | 'VO-vwo'
+  | 'VSO-vervolg'
+  | 'VSO-arbeidsmarkt'
+  | 'VSO-dagbesteding'
+  | 'MBO-1'
+  | 'MBO-2'
+  | 'MBO-3'
+  | 'MBO-4'
+  | 'HBO-ba'
+  | 'HBO-ma'
+  | 'WO-ba'
+  | 'WO-ma';
+
+export interface ActivitySuggestion {
+  title: string;
+  description: string;
+  duration?: string; // bijv. "45 min"
+  why: string; // korte rationale
+}
+
+export interface AssessmentSuggestion {
+  title: string;
+  description: string;
+  formative?: boolean;
+  summative?: boolean;
+  why: string;
+}
+
+export interface SuggestionBundle {
+  activities: ActivitySuggestion[];
+  assessments: AssessmentSuggestion[];
+}
+

--- a/Leerdoelengenerator-main/src/utils/suggestionHelpers.ts
+++ b/Leerdoelengenerator-main/src/utils/suggestionHelpers.ts
@@ -1,0 +1,38 @@
+import type { GoalOrientation, EducationLevel } from '@/types/learning';
+import type { LearningObjectiveContext } from '@/types/context';
+
+export function inferGoalOrientation(text: string): GoalOrientation {
+  const t = text.toLowerCase();
+  if (/(reflect|houding|attitude|samenwerk|feedback|verantwoordelijkheid)/.test(t)) {
+    return 'attitude';
+  }
+  if (/(toepassen|vaardig|vaardigheid|simulatie|oefen|uitvoer|demonstratie)/.test(t)) {
+    return 'vaardigheid';
+  }
+  return 'kennis';
+}
+
+export function mapEducationLevel(ctx: LearningObjectiveContext): EducationLevel {
+  switch (ctx.education) {
+    case 'VO':
+      if (ctx.voLevel === 'havo') return 'VO-havo';
+      if (ctx.voLevel === 'vwo') return 'VO-vwo';
+      return 'VO-vmbo';
+    case 'MBO':
+      if (ctx.level.includes('1')) return 'MBO-1';
+      if (ctx.level.includes('2')) return 'MBO-2';
+      if (ctx.level.includes('3')) return 'MBO-3';
+      return 'MBO-4';
+    case 'HBO':
+      return ctx.level === 'Master' ? 'HBO-ma' : 'HBO-ba';
+    case 'WO':
+      return ctx.level === 'Master' ? 'WO-ma' : 'WO-ba';
+    case 'VSO':
+      if (ctx.level.includes('Vervolg')) return 'VSO-vervolg';
+      if (ctx.level.includes('Dagbested')) return 'VSO-dagbesteding';
+      return 'VSO-arbeidsmarkt';
+    default:
+      return 'HBO-ba';
+  }
+}
+


### PR DESCRIPTION
## Summary
- define learning suggestion types and mapping rules
- attach suggestions based on goal orientation and education level
- display copyable activity and assessment suggestions in UI

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b04f892d3483309ad6b5a808b5b904