### PR TITLE
Implement two-lane AI usage datamodel and templates

### DIFF
--- a/Leerdoelengenerator-main/src/lib/twoLane.ts
+++ b/Leerdoelengenerator-main/src/lib/twoLane.ts
@@ -1,0 +1,87 @@
+import type { LearningObjectiveContext } from '../types/context';
+
+export interface TwoLaneOutput {
+  objective: string;
+  explanation: string;
+  rubric: string[];
+  verification: string[];
+  aiUsage: 'verboden' | 'beperkt' | 'toegestaan' | 'verplicht';
+  transparencyRequirements: string[];
+  ethicsFlags: string[];
+}
+
+// Standaard transparantie-eisen voor Baan 2
+const DEFAULT_TRANSPARENCY = [
+  'Logboek met gebruikte AI-tools (naam/versie), prompts en tijdstempels',
+  'Annotaties op AI-bijdragen in het product (wat is AI, wat is eigen werk)',
+  'Kritische evaluatie van AI-output en aangebrachte correcties',
+  'Reflectie op leren met AI (zonder en met AI, strategieën)',
+];
+
+// Standaard ethische aandachtspunten
+const DEFAULT_ETHICS = ['privacy', 'bias', 'bronvermelding'];
+
+/**
+ * Genereer leerdoel + uitleg + rubric volgens Two-Lane benadering.
+ * Deze logica is bewust eenvoudig en sjabloongebaseerd zodat hij
+ * deterministisch werkt in tests zonder LLM.
+ */
+export function generateTwoLaneOutput(ctx: LearningObjectiveContext): TwoLaneOutput {
+  const lane = ctx.lane === 'baan2' ? 'baan2' : 'baan1';
+  const aiUsage: 'verboden' | 'beperkt' | 'toegestaan' | 'verplicht' =
+    ctx.ai_usage ?? (lane === 'baan2' ? 'toegestaan' : 'beperkt');
+
+  if (lane === 'baan1') {
+    const objective = `Na afloop van deze les kan de student, zonder AI, ${ctx.original}`;
+    const explanation =
+      'Deze taak vindt plaats onder toezicht en meet individuele bekwaamheid; AI-gebruik is beperkt of niet toegestaan.';
+    const rubric = [
+      'Kerntaak/vaardigheid',
+      'Veiligheid & hygiëne',
+      'Tijd & nauwkeurigheid',
+      'Vakkennis & begrip',
+      'Professionaliteit & ethiek (AI-vrij)',
+    ];
+    return {
+      objective,
+      explanation,
+      rubric,
+      verification: [],
+      aiUsage,
+      transparencyRequirements: [],
+      ethicsFlags: ctx.ethics_flags ?? [],
+    };
+  }
+
+  // Baan 2
+  const transparency = ctx.transparency_requirements && ctx.transparency_requirements.length > 0
+    ? ctx.transparency_requirements
+    : DEFAULT_TRANSPARENCY;
+
+  const objective =
+    `Na afloop van deze les kan de student, met doelmatig en verantwoord gebruik van AI (${aiUsage}), ${ctx.original}, ` +
+    'AI-output beoordelen op juistheid/bias, keuzes verantwoorden en het leerproces transparant maken via logboek.';
+
+  const explanation =
+    'AI is toegestaan of vereist; de student toont transparantie, verantwoording en reflectie en houdt rekening met privacy/AVG en AI Act.';
+
+  const rubric = [
+    'Resultaatkwaliteit in context',
+    'AI-geletterdheid (keuze, promptkwaliteit, evaluatie)',
+    'Transparantie & verantwoording',
+    'Ethiek/AVG/AI-Act alertheid',
+    'Reflectie op leerproces',
+  ];
+
+  return {
+    objective,
+    explanation,
+    rubric,
+    verification: transparency,
+    aiUsage,
+    transparencyRequirements: transparency,
+    ethicsFlags: ctx.ethics_flags ?? DEFAULT_ETHICS,
+  };
+}
+
+export default generateTwoLaneOutput;

--- a/Leerdoelengenerator-main/src/tests/twoLane.test.ts
+++ b/Leerdoelengenerator-main/src/tests/twoLane.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { generateTwoLaneOutput } from '../lib/twoLane';
+import type { LearningObjectiveContext } from '../types/context';
+
+describe('Two-Lane generator', () => {
+  it('Baan 1 zet AI-gebruik op beperkt en bevat geen transparantie-eisen', () => {
+    const ctx: LearningObjectiveContext = {
+      original: 'eenvoudige wondverzorging uitvoeren bij een gesimuleerde cliënt, conform richtlijnen',
+      education: 'MBO',
+      level: 'Niveau 2',
+      domain: 'Zorg',
+      lane: 'baan1',
+    } as any; // overige velden zijn niet relevant voor deze test
+    const out = generateTwoLaneOutput(ctx);
+    expect(out.aiUsage).toBe('beperkt');
+    expect(out.objective).toContain('zonder AI');
+    expect(out.verification.length).toBe(0);
+    expect(out.rubric).toContain('Kerntaak/vaardigheid');
+  });
+
+  it('Baan 2 genereert transparantie-eisen en staat AI toe', () => {
+    const ctx: LearningObjectiveContext = {
+      original: 'eenvoudige wondverzorging uitvoeren bij een gesimuleerde cliënt, conform richtlijnen',
+      education: 'MBO',
+      level: 'Niveau 2',
+      domain: 'Zorg',
+      lane: 'baan2',
+    } as any;
+    const out = generateTwoLaneOutput(ctx);
+    expect(out.aiUsage).toBe('toegestaan');
+    expect(out.objective).toContain('met doelmatig en verantwoord gebruik van AI');
+    expect(out.verification.length).toBeGreaterThan(0);
+    expect(out.rubric).toContain('AI-geletterdheid (keuze, promptkwaliteit, evaluatie)');
+  });
+
+  it('Business-domein met verplicht AI-gebruik vermeldt verplicht in doel', () => {
+    const ctx: LearningObjectiveContext = {
+      original: 'een financieel plan opstellen voor een start-up',
+      education: 'HBO',
+      level: 'Bachelor',
+      domain: 'Business',
+      lane: 'baan2',
+      ai_usage: 'verplicht',
+    } as any;
+    const out = generateTwoLaneOutput(ctx);
+    expect(out.aiUsage).toBe('verplicht');
+    expect(out.objective).toContain('verplicht');
+    expect(out.verification.length).toBeGreaterThan(0);
+  });
+
+  it('ICT-domein in Baan 1 houdt AI buiten de toets', () => {
+    const ctx: LearningObjectiveContext = {
+      original: 'een netwerkconfiguratie implementeren volgens specificaties',
+      education: 'MBO',
+      level: 'Niveau 4',
+      domain: 'ICT',
+      lane: 'baan1',
+    } as any;
+    const out = generateTwoLaneOutput(ctx);
+    expect(out.objective).toContain('zonder AI');
+    expect(out.aiUsage).toBe('beperkt');
+  });
+});

--- a/Leerdoelengenerator-main/src/types/context.ts
+++ b/Leerdoelengenerator-main/src/types/context.ts
@@ -8,6 +8,36 @@ export interface LearningObjectiveContext {
   domain: string;
   assessment?: string;
   lane?: 'baan1' | 'baan2';
+  /**
+   * Beschrijft hoe AI in deze taak gebruikt mag worden.
+   *
+   * - "verboden": AI-gebruik niet toegestaan.
+   * - "beperkt": Alleen gecontroleerd/toegestaan onder toezicht.
+   * - "toegestaan": AI-gebruik is toegestaan, mits verantwoord.
+   * - "verplicht": AI-gebruik is vereist en onderdeel van de taak.
+   */
+  ai_usage?: 'verboden' | 'beperkt' | 'toegestaan' | 'verplicht';
+  /**
+   * Transparantie-eisen die de student moet aanleveren als bewijs
+   * van verantwoord AI-gebruik (logboek, versiebeheer, reflectie, ...).
+   */
+  transparency_requirements?: string[];
+  /**
+   * Ethische aandachtspunten zoals privacy of bias die voor deze
+   * taak relevant zijn.
+   */
+  ethics_flags?: string[];
+  /**
+   * Informatie voor constructive alignment van het leerdoel.
+   * bloomLevel: het niveau in Bloom.
+   * context: beschrijving van de taakcontext.
+   * constraints: voorwaarden of beperkingen voor de taak.
+   */
+  alignment?: {
+    bloomLevel?: string;
+    context?: string;
+    constraints?: string;
+  };
   voLevel?: VoLevel; // required when education === 'VO'
   voGrade?: number;  // required when education === 'VO'
   vsoCluster?: VSOCluster; // required when education === 'VSO'


### PR DESCRIPTION
## Summary
- extend learning objective context with AI usage, transparency, ethics and alignment fields
- add deterministic two-lane template generator that produces lane-specific learning goals, explanations and rubrics
- cover zorg, business and ICT lanes with unit tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05378e9c08330aad952f42f137f78