### PR TITLE
Add glossary page with searchable AI terms

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -812,6 +812,14 @@ function App() {
                   <Upload className="w-4 h-4" />
                   <span>KD Importeren</span>
                 </button>
+
+                <a
+                  href="/begrippen"
+                  className="flex items-center space-x-2 bg-gray-100 text-gray-800 h-11 px-4 rounded-lg font-medium hover:bg-gray-200 transition-all duration-200 shadow-md hover:shadow-lg"
+                >
+                  <BookOpen className="w-4 h-4" />
+                  <span>Begrippen</span>
+                </a>
               </div>
 
               <button
@@ -866,6 +874,15 @@ function App() {
                 <Upload className="w-4 h-4" />
                 <span>KD Importeren</span>
               </button>
+
+              <a
+                href="/begrippen"
+                onClick={() => setMenuOpen(false)}
+                className="flex items-center justify-center space-x-2 bg-gray-100 text-gray-800 h-11 px-4 rounded-lg font-medium hover:bg-gray-200 transition-all duration-200 shadow-md hover:shadow-lg w-full"
+              >
+                <BookOpen className="w-4 h-4" />
+                <span>Begrippen</span>
+              </a>
             </div>
           )}
         </div>

--- a/Leerdoelengenerator-main/src/components/EmptyState.tsx
+++ b/Leerdoelengenerator-main/src/components/EmptyState.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+export default function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div className="border rounded-xl p-6 text-center opacity-70">
+      {children}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/components/Glossary/Filters.tsx
+++ b/Leerdoelengenerator-main/src/components/Glossary/Filters.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { GlossaryCategory } from '@/types/glossary';
+
+const letters = ['Alle',...Array.from('ABCDEFGHIJKLMNOPQRSTUVWXYZ')];
+const categories: (GlossaryCategory|'Alle')[] = [
+  'Alle','AI & Geletterdheid','Toetsing & Examinering','Kaders & Wetgeving',
+  'Didactiek & Curriculum','Datagebruik & Privacy','Onderwijsniveaus'
+];
+
+export default function Filters({
+  q, letter, category, onChange
+}: {
+  q: string; letter: string; category: (GlossaryCategory|'Alle');
+  onChange: (v:{q?:string;letter?:string;category?:(GlossaryCategory|'Alle')})=>void;
+}) {
+  return (
+    <div className="space-y-3">
+      <input
+        aria-label="Zoeken in begrippen"
+        className="w-full border rounded-xl px-3 py-2"
+        placeholder="Zoek op term, betekenis of synoniem…"
+        value={q}
+        onChange={e=>onChange({q:e.target.value})}
+      />
+      <div className="flex flex-wrap gap-2">
+        {letters.map(l=>(
+          <button key={l}
+            className={`px-2 py-1 rounded-full text-sm border ${letter===l?'bg-black text-white':'bg-white'}`}
+            onClick={()=>onChange({letter:l})}
+            aria-pressed={letter===l}
+          >{l}</button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {categories.map(c=>(
+          <button key={c}
+            className={`px-3 py-1 rounded-full text-sm border ${category===c?'bg-black text-white':'bg-white'}`}
+            onClick={()=>onChange({category:c})}
+            aria-pressed={category===c}
+          >{c}</button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/components/Glossary/ItemCard.tsx
+++ b/Leerdoelengenerator-main/src/components/Glossary/ItemCard.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { GlossaryItem } from '@/types/glossary';
+
+export default function ItemCard({item}:{item:GlossaryItem}) {
+  const link = `#${item.id}`;
+  const copy = async () => {
+    await navigator.clipboard.writeText(window.location.origin + '/begrippen' + link);
+  };
+  return (
+    <article id={item.id} className="rounded-2xl border p-4 scroll-mt-24">
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-lg font-semibold">{item.term}</h3>
+        <div className="flex gap-2">
+          <a href={link} aria-label="Deeplink naar begrip" className="text-sm underline">#</a>
+          <button onClick={copy} className="text-sm underline">Kopieer link</button>
+        </div>
+      </div>
+      <p className="mt-2">{item.definition}</p>
+      <div className="mt-3 text-xs opacity-70">
+        <span className="mr-3">Categorie: {item.category}</span>
+        {item.alsoKnownAs?.length ? <span>Ook: {item.alsoKnownAs.join(', ')}</span> : null}
+      </div>
+      {item.seeAlso?.length ? (
+        <div className="mt-2 text-sm">
+          Zie ook: {item.seeAlso.map(id=>(
+            <a key={id} className="underline mr-2" href={`#${id}`}>{id}</a>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/Leerdoelengenerator-main/src/components/Glossary/List.tsx
+++ b/Leerdoelengenerator-main/src/components/Glossary/List.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useMemo, useState, useEffect } from 'react';
+import Filters from './Filters';
+import ItemCard from './ItemCard';
+import { filterGlossary } from '@/lib/searchGlossary';
+import { GlossaryCategory } from '@/types/glossary';
+import EmptyState from '@/components/EmptyState';
+
+export default function GlossaryList() {
+  const [q,setQ]=useState('');
+  const [letter,setLetter]=useState('Alle');
+  const [category,setCategory]=useState<GlossaryCategory|'Alle'>('Alle');
+
+  // Scroll naar hash bij laden
+  useEffect(()=>{
+    if (window.location.hash) {
+      document.querySelector(window.location.hash)?.scrollIntoView({behavior:'smooth', block:'start'});
+    }
+  },[]);
+
+  const items = useMemo(()=>filterGlossary({q,letter,category}),[q,letter,category]);
+
+  return (
+    <div className="space-y-6">
+      <Filters q={q} letter={letter} category={category}
+        onChange={({q,letter,category})=>{
+          if(q!==undefined) setQ(q);
+          if(letter!==undefined) setLetter(letter);
+          if(category!==undefined) setCategory(category);
+        }}
+      />
+      {items.length===0 ? (
+        <EmptyState>
+          Geen resultaten. Probeer een andere zoekterm of filter.
+        </EmptyState>
+      ) : (
+        <div className="grid md:grid-cols-2 gap-4">
+          {items.map(it => <ItemCard key={it.id} item={it}/>)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/data/glossary.json
+++ b/Leerdoelengenerator-main/src/data/glossary.json
@@ -1,0 +1,73 @@
+[
+  {"id":"ai-ready-leerdoel","term":"AI-ready leerdoel","definition":"Een leerdoel dat duidelijk maakt wat een student moet aantonen in een context waar AI bestaat. Het specificeert of AI-gebruik is toegestaan of juist uitgesloten, en wat de student zélf moet kunnen (met of zonder AI). Dit borgt validiteit van toetsing en bereidt voor op AI-rijke beroepspraktijk.","category":"Didactiek & Curriculum","alsoKnownAs":["AI-bewust leerdoel"],"seeAlso":["two-lane-approach","constructive-alignment"]},
+
+  {"id":"two-lane-approach","term":"Two-Lane approach (Baan 1 & Baan 2)","definition":"Een toetsprogramma heeft idealiter beide sporen: Baan 1 (zonder AI) borgt cruciale basiskennis en -vaardigheden en de diplomawaarde; Baan 2 (met AI) bereidt voor op realistische beroepssituaties waarin AI gangbaar is. Samen zorgen ze voor constructieve afstemming en geloofwaardige diplomawaarde.","category":"Toetsing & Examinering","alsoKnownAs":["Twee-sporenbeleid","Baan 1 / Baan 2"],"seeAlso":["authenticiteit","validiteit","open-book-open-web"]},
+
+  {"id":"blooms-taxonomie","term":"Bloom’s taxonomie","definition":"Een hiërarchie van cognitieve niveaus: Onthouden, Begrijpen, Toepassen, Analyseren, Evalueren, Creëren. Helpt bij het formuleren van leerdoelen en het kiezen van passende activiteiten en toetsvormen.","category":"Didactiek & Curriculum","seeAlso":["constructive-alignment"]},
+
+  {"id":"ai-go","term":"AI-GO raamwerk (AI-geletterdheid)","definition":"Raamwerk voor AI-geletterdheid in het onderwijs met vier componenten in samenhang: Kennis, Vaardigheden, Attitudes en Ethiek. Benadrukt pedagogische dimensie en beïnvloedende factoren (individu, team, organisatie, beleid).","category":"AI & Geletterdheid","alsoKnownAs":["AI-GO"],"seeAlso":["ethiek","kritisch-denken"]},
+
+  {"id":"publieke-waarden","term":"Publieke waarden (rechtvaardigheid, menselijkheid, autonomie)","definition":"Waardenkader voor verantwoord gebruik van studiedata en AI. Rechtvaardigheid (inclusie, eerlijkheid, veiligheid, transparantie), Menselijkheid (betekenisvol contact, menselijke blik), Autonomie (zelfbeschikking van student en docent, privacybalans).","category":"Kaders & Wetgeving","seeAlso":["avg","ai-act"]},
+
+  {"id":"studiedata","term":"Studiedata","definition":"Gegevens die in en rond onderwijs ontstaan (bijv. cijfers, aanwezigheid, LMS-logs, ingeleverd werk). Worden gebruikt voor leren, begeleiden, kwaliteitszorg en onderzoek — met strikte aandacht voor privacy en doelbinding.","category":"Datagebruik & Privacy","seeAlso":["avg","privacy-by-design"]},
+
+  {"id":"avg","term":"AVG (privacy)","definition":"Algemene Verordening Gegevensbescherming. Bij gebruik van studiedata en AI gelden o.a. doelbinding, grondslag, minimale gegevensverwerking, juistheid, bewaartermijnen, beveiliging, rechten van betrokkenen en soms een DPIA.","category":"Kaders & Wetgeving","alsoKnownAs":["GDPR"],"seeAlso":["dpia","privacy-by-design"]},
+
+  {"id":"ai-act","term":"AI Act (EU)","definition":"Europese verordening voor AI-systemen met risicoklassen: verboden, hoog risico (met strenge vereisten), transparantie, minimaal risico. In onderwijs zijn o.a. systemen voor toelating, evaluatie en proctoring vaak hoog risico.","category":"Kaders & Wetgeving","seeAlso":["risicobeoordeling","menselijk-toezicht"]},
+
+  {"id":"constructive-alignment","term":"Constructive alignment","definition":"Het op elkaar afstemmen van leerdoelen, leeractiviteiten en toetsing. Bij AI-integratie bepaalt dit ook wanneer AI wel/niet gepast is en wat studenten zélf moeten aantonen.","category":"Didactiek & Curriculum","seeAlso":["ai-ready-leerdoel","two-lane-approach"]},
+
+  {"id":"authenticiteit","term":"Authenticiteit","definition":"Mate waarin een toets echte, relevante taken uit de praktijk benadert. Verkleint kans op generieke AI-antwoorden en verhoogt betekenisvol leren.","category":"Toetsing & Examinering","seeAlso":["mondeling-toetsen","portfolio"]},
+
+  {"id":"validiteit","term":"Validiteit","definition":"Toetst de toets wat hij beoogt te toetsen? Cruciaal bij AI: beoordeel of het individuele kunnen zichtbaar blijft, óók wanneer AI is toegestaan.","category":"Toetsing & Examinering","seeAlso":["betrouwbaarheid","two-lane-approach"]},
+
+  {"id":"betrouwbaarheid","term":"Betrouwbaarheid","definition":"Consistentie van beoordeling. Verhoog via heldere criteria, rubrics, kalibratie en waar nodig toezicht/condities.","category":"Toetsing & Examinering","seeAlso":["rubric"]},
+
+  {"id":"formatief","term":"Formatief handelen","definition":"Doel: leren versterken. Feedback, tussenproducten en iteraties (ook met AI) om het leerproces te sturen. Geen cijfer als eindbeslissing.","category":"Toetsing & Examinering","seeAlso":["summatief","procesvorm"]},
+
+  {"id":"summatief","term":"Summatief toetsen","definition":"Eindoordeel met gevolgen (slagen/zakken, studiepunten). Voor kernbekwaamheden vaak in Baan 1 (zonder AI) of onder strikte condities.","category":"Toetsing & Examinering","seeAlso":["formatief","two-lane-approach"]},
+
+  {"id":"rubric","term":"Rubric","definition":"Beoordelingsmatrix met criteria en prestatieniveaus. Vergroot transparantie, betrouwbaarheid en gerichte feedback.","category":"Toetsing & Examinering"},
+
+  {"id":"portfolio","term":"Portfolio","definition":"Verzameling van bewijzen (producten, proceslog, reflecties) die groei en bekwaamheid aantonen. Goed inzetbaar bij AI-bewuste beoordeling.","category":"Toetsing & Examinering"},
+
+  {"id":"peer-assessment","term":"Peer assessment","definition":"Studenten beoordelen elkaars werk (formatief of deels summatief) op basis van criteria/rubrics; versterkt feedbackgeletterdheid.","category":"Toetsing & Examinering"},
+
+  {"id":"open-book-open-web","term":"Open-book / Open-web toetsen","definition":"Toetsvormen waarbij bronnen (incl. AI) zijn toegestaan; items focussen op toepassing, analyse en verantwoording, niet op reproduceerbare kennis.","category":"Toetsing & Examinering","seeAlso":["two-lane-approach"]},
+
+  {"id":"mondeling-toetsen","term":"Mondeling toetsen","definition":"Mondelinge verdediging/demonstratie om eigen inzicht, redenering en herkomst van werk zichtbaar te maken. Verkleint ongewenst AI-gebruik.","category":"Toetsing & Examinering"},
+
+  {"id":"procesvorm","term":"Procesvorm","definition":"De aanpak/werkwijze (samenwerken, onderzoek, itereren, reflectie) die leidde tot het product. Belangrijk om AI-bijdragen en leren zichtbaar te maken.","category":"Didactiek & Curriculum","seeAlso":["productvorm"]},
+
+  {"id":"productvorm","term":"Productvorm","definition":"Het tastbare resultaat (verslag, ontwerp, video, code). Bij AI-bewuste opdrachten gaat de aandacht óók naar het proces en verantwoording.","category":"Didactiek & Curriculum","seeAlso":["procesvorm"]},
+
+  {"id":"adaptieve-simulaties","term":"Adaptieve AI & simulaties","definition":"AI-gestuurde oefen- en praktijksituaties die zich aanpassen aan handelen van de student. Geschikt voor authentieke, rijke beoordeling.","category":"Didactiek & Curriculum","alsoKnownAs":["virtuele scenario’s"]},
+
+  {"id":"kritisch-denken","term":"Kritisch denken (AI)","definition":"AI-output beoordelen op correctheid, bias en toepasbaarheid; afwegen welke rol AI mag spelen in beslissingen en bewijsvoering.","category":"AI & Geletterdheid"},
+
+  {"id":"privacy-by-design","term":"Privacy by design/default","definition":"Privacy is vanaf het ontwerp geborgd (dataminimalisatie, veilige opslag, standaard ‘uit’). Belangrijk bij inzet van AI-tools in onderwijs.","category":"Datagebruik & Privacy","seeAlso":["avg","dpia"]},
+
+  {"id":"dpia","term":"DPIA","definition":"Data Protection Impact Assessment. Verplicht bij verwerkingen met hoog privacyrisico. In kaart brengen, risicobeperking plannen en vastleggen.","category":"Datagebruik & Privacy","seeAlso":["avg"]},
+
+  {"id":"examencommissie","term":"Examencommissie (rol bij AI)","definition":"Bewaakt kwaliteit en rechtmatigheid van toetsing, adviseert bij AI-vraagstukken (authenticiteit, fraude, beleid) en casuïstiek.","category":"Toetsing & Examinering","seeAlso":["validiteit","betrouwbaarheid"]},
+
+  {"id":"risicobeoordeling","term":"Risicobeoordeling (AI in toetsing)","definition":"Systematisch risico’s in kaart brengen (fraude, ongelijkheid, privacy), prioriteren en maatregelen nemen; periodiek herzien.","category":"Kaders & Wetgeving","seeAlso":["ai-act","avg"]},
+
+  {"id":"werkgroepen","term":"Werkgroepen / governance","definition":"Formele adviesgroepen en informele communities om AI-beleid, didactiek en tooling te ontwikkelen, toetsen en borgen.","category":"Kaders & Wetgeving"},
+
+  {"id":"onderwijsniveaus","term":"Onderwijsniveaus (VO/MBO/HBO/WO/VSO)","definition":"VO: vmbo/havo/vwo. MBO: niveau 1–4. HBO/WO: ba/ma. VSO-uitstroomprofielen: vervolgonderwijs, arbeidsmarktgericht, dagbesteding.","category":"Onderwijsniveaus"},
+
+  {"id":"uitstroomprofielen-vso","term":"Uitstroomprofielen VSO","definition":"Richting waarin de leerling zich voorbereidt: vervolgonderwijs, arbeidsmarktgericht of dagbesteding; beïnvloedt formulering en beoordeling van leerdoelen.","category":"Onderwijsniveaus","seeAlso":["onderwijsniveaus"]},
+
+  {"id":"menselijk-toezicht","term":"Menselijk toezicht (AI)","definition":"AI mag geen autonoom examenbesluit nemen. Bij hoog-risico AI zijn menselijk toezicht en logging/traceerbaarheid verplicht.","category":"Kaders & Wetgeving","seeAlso":["ai-act"]},
+
+  {"id":"transparantie-verantwoording","term":"Transparantie & verantwoording","definition":"Duidelijk zijn over wanneer en hoe AI is gebruikt, inclusief motivatie en effecten. Studenten leggen gebruik vast en lichten toe.","category":"AI & Geletterdheid","seeAlso":["procesvorm"]},
+
+  {"id":"feedbackgeletterdheid","term":"Feedbackgeletterdheid","definition":"Vaardigheid om feedback (ook AI-feedback) te zoeken, begrijpen en vertalen naar verbeteracties; essentieel bij formatief handelen.","category":"Didactiek & Curriculum"},
+
+  {"id":"ethiek","term":"Ethiek (AI)","definition":"Morele afwegingen: fairness, schadebeperking, uitlegplicht, impact op mens en maatschappij. Fundament onder AI-geletterdheid.","category":"AI & Geletterdheid"},
+
+  {"id":"detectietools-beperking","term":"Beperkingen AI-detectietools","definition":"AI-detectie (bv. ‘AI-percentage’) is niet sluitend en vraagt altijd menselijk onderzoek, hoor- en wederhoor en aanvullende bewijzen.","category":"Toetsing & Examinering","seeAlso":["examencommissie"]},
+
+  {"id":"logboek-versiegeschiedenis","term":"Logboek & versiegeschiedenis","definition":"Procesbewijzen (prompts, iteraties, bronnen, versieverschillen) die laten zien hoe werk tot stand kwam en wat de student leerde.","category":"Toetsing & Examinering","seeAlso":["procesvorm","transparantie-verantwoording"]}
+]

--- a/Leerdoelengenerator-main/src/lib/searchGlossary.ts
+++ b/Leerdoelengenerator-main/src/lib/searchGlossary.ts
@@ -1,0 +1,28 @@
+import data from '@/data/glossary.json';
+import { GlossaryItem, GlossaryCategory } from '@/types/glossary';
+
+export function getAll(): GlossaryItem[] { return data as GlossaryItem[]; }
+
+export function filterGlossary(params: {
+  q?: string;
+  letter?: string;
+  category?: GlossaryCategory | 'Alle';
+}): GlossaryItem[] {
+  let items = getAll();
+  const { q, letter, category } = params;
+
+  if (letter && letter !== 'Alle') {
+    items = items.filter(i => i.term.toUpperCase().startsWith(letter.toUpperCase()));
+  }
+  if (category && category !== 'Alle') {
+    items = items.filter(i => i.category === category);
+  }
+  if (q && q.trim()) {
+    const t = q.toLowerCase();
+    items = items.filter(i =>
+      (i.term + ' ' + i.definition + ' ' + (i.alsoKnownAs ?? []).join(' '))
+      .toLowerCase().includes(t)
+    );
+  }
+  return items.sort((a,b)=> a.term.localeCompare(b.term, 'nl'));
+}

--- a/Leerdoelengenerator-main/src/lib/slug.ts
+++ b/Leerdoelengenerator-main/src/lib/slug.ts
@@ -1,0 +1,4 @@
+export const toSlug = (s: string) =>
+  s.toLowerCase().trim()
+   .replace(/[^\w\s-]/g, '')
+   .replace(/\s+/g, '-');

--- a/Leerdoelengenerator-main/src/main.tsx
+++ b/Leerdoelengenerator-main/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import HomePage from '@/pages/index';
 import About from '@/pages/About';
+import GlossaryPage from '@/pages/begrippen';
 import Layout from '@/components/Layout';
 import RouteTracker from '@/components/RouteTracker';
 import CookieBanner from '@/components/CookieBanner';
@@ -16,6 +17,7 @@ createRoot(rootElement).render(
       <RouteTracker />
       <Routes>
         <Route path="/" element={<Layout><HomePage /></Layout>} />
+        <Route path="/begrippen" element={<Layout><GlossaryPage /></Layout>} />
         <Route path="/over" element={<Layout><About /></Layout>} />
       </Routes>
       <CookieBanner />

--- a/Leerdoelengenerator-main/src/pages/begrippen.tsx
+++ b/Leerdoelengenerator-main/src/pages/begrippen.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import GlossaryList from '@/components/Glossary/List';
+
+export default function BegrippenPage() {
+  useEffect(() => {
+    document.title = 'Begrippen | Leerdoelengenerator';
+  }, []);
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10">
+      <header className="mb-8 space-y-2">
+        <h1 className="text-3xl font-bold">Begrippen</h1>
+        <p className="opacity-80">
+          Korte, praktische uitleg bij alle begrippen die je nodig hebt om AI-ready leerdoelen te maken en te beoordelen.
+        </p>
+      </header>
+      <GlossaryList />
+      <footer className="mt-12 text-sm opacity-70">
+        Mis je een begrip? <a className="underline" href="/contact">Laat het weten</a>.
+      </footer>
+    </main>
+  );
+}

--- a/Leerdoelengenerator-main/src/types/glossary.ts
+++ b/Leerdoelengenerator-main/src/types/glossary.ts
@@ -1,0 +1,16 @@
+export type GlossaryCategory =
+  | 'AI & Geletterdheid'
+  | 'Toetsing & Examinering'
+  | 'Kaders & Wetgeving'
+  | 'Didactiek & Curriculum'
+  | 'Datagebruik & Privacy'
+  | 'Onderwijsniveaus';
+
+export interface GlossaryItem {
+  id: string;            // slug
+  term: string;          // getoonde term
+  definition: string;    // korte, heldere uitleg (2–6 zinnen)
+  category: GlossaryCategory;
+  alsoKnownAs?: string[]; // synoniemen
+  seeAlso?: string[];     // verwijzingen naar andere ids
+}

--- a/Leerdoelengenerator-main/tsconfig.app.json
+++ b/Leerdoelengenerator-main/tsconfig.app.json
@@ -17,6 +17,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
+    "resolveJsonModule": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- Create `/begrippen` page with glossary list and responsive filters for term, letter and category.
- Add comprehensive glossary dataset and helper utilities for slugging and filtering.
- Link glossary in main navigation for both desktop and mobile views.

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - react-router-dom)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05559b31483309bdcc3089858918f