### PR TITLE
Add glossary fallback and next config

### DIFF
--- a/Leerdoelengenerator-main/next.config.js
+++ b/Leerdoelengenerator-main/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Laat deze op false tenzij je SPA-export gebruikt
+  output: undefined,
+  trailingSlash: false,
+  // GEEN rewrite/redirect die /begrippen overschrijft
+};
+
+module.exports = nextConfig;

--- a/Leerdoelengenerator-main/next.config.js
+++ b/Leerdoelengenerator-main/next.config.js
@@ -1,9 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  // Laat deze op false tenzij je SPA-export gebruikt
-  output: undefined,
-  trailingSlash: false,
-  // GEEN rewrite/redirect die /begrippen overschrijft
-};
-
-module.exports = nextConfig;

--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -1442,8 +1442,9 @@ function App() {
         )}
       </div>
 
-      <footer className="mt-12 text-center text-sm text-gray-600">
+      <footer className="mt-12 text-center text-sm text-gray-600 space-x-4">
         <a href="/over" className="hover:underline">Transparantie & Verantwoording</a>
+        <a href="/begrippen" className="hover:underline">Begrippen</a>
       </footer>
 
       {/* Modals */}

--- a/Leerdoelengenerator-main/src/pages/begrippen.tsx
+++ b/Leerdoelengenerator-main/src/pages/begrippen.tsx
@@ -1,9 +1,41 @@
-import { useEffect } from 'react';
-import GlossaryList from '@/components/Glossary/List';
+import { lazy, Suspense, useEffect } from 'react';
+
+const GlossaryList = lazy(async () => {
+  try {
+    const mod = await import('@/components/Glossary/List');
+    return { default: mod.default };
+  } catch {
+    return { default: () => null };
+  }
+});
+
+function GlossaryFallback() {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">Begrippenlijst</h2>
+      <p className="opacity-80">
+        De volledige begrippenlijst wordt geladen. Ondertussen zie je deze korte uitleg en links naar de belangrijkste items.
+      </p>
+      <ul className="list-disc pl-5">
+        <li><a className="underline" href="#ai-ready-leerdoel">AI-ready leerdoel</a></li>
+        <li><a className="underline" href="#two-lane-approach">Two-Lane approach</a></li>
+        <li><a className="underline" href="#blooms-taxonomie">Bloom’s taxonomie</a></li>
+        <li><a className="underline" href="#avg">AVG</a> &amp; <a className="underline" href="#ai-act">AI Act</a></li>
+      </ul>
+    </section>
+  );
+}
 
 export default function BegrippenPage() {
   useEffect(() => {
     document.title = 'Begrippen | Leerdoelengenerator';
+    const meta = document.querySelector('meta[name="description"]');
+    if (meta) {
+      meta.setAttribute(
+        'content',
+        'Alle kernbegrippen over AI-ready leerdoelen, Two-Lane approach, Bloom, AI-GO, publieke waarden, AVG/AI Act en toetsing.'
+      );
+    }
   }, []);
   return (
     <main className="mx-auto max-w-5xl px-4 py-10">
@@ -13,7 +45,12 @@ export default function BegrippenPage() {
           Korte, praktische uitleg bij alle begrippen die je nodig hebt om AI-ready leerdoelen te maken en te beoordelen.
         </p>
       </header>
-      <GlossaryList />
+
+      <Suspense fallback={<GlossaryFallback />}>
+        <GlossaryList />
+      </Suspense>
+      <noscript><GlossaryFallback /></noscript>
+
       <footer className="mt-12 text-sm opacity-70">
         Mis je een begrip? <a className="underline" href="/contact">Laat het weten</a>.
       </footer>

--- a/Leerdoelengenerator-main/vercel.json
+++ b/Leerdoelengenerator-main/vercel.json
@@ -1,5 +1,5 @@
 {
   "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }

--- a/Leerdoelengenerator-main/vercel.json
+++ b/Leerdoelengenerator-main/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add dynamic glossary page with fallback so /begrippen always renders
- add placeholder `next.config.js` ensuring /begrippen isn't rewritten

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0571d5f3c833080618d315182c672