### PR TITLE
Fix feedback mailer to send through Resend

### DIFF
--- a/Leerdoelengenerator-main/api/feedback.ts
+++ b/Leerdoelengenerator-main/api/feedback.ts
@@ -6,27 +6,52 @@ export default async function handler(req: any, res: any) {
   if (req.method !== "POST") {
     return res.status(405).end();
   }
+
   const { stars, comment, path, ua } = req.body || {};
   const rating = Number(stars);
   if (!Number.isFinite(rating) || rating < 1 || rating > 5) {
-    return res.status(400).json({ error: "invalid stars" });
+    return res.status(400).json({ error: "Invalid stars (1–5)" });
   }
+
+  const to = process.env.FEEDBACK_TO_EMAIL;
+  if (!to) {
+    return res.status(500).json({ error: "FEEDBACK_TO_EMAIL not set" });
+  }
+
+  const site = process.env.SITE_NAME || "LeerdoelenGenerator";
+
+  const html = `
+    <div style="font-family:system-ui,Segoe UI,Arial">
+      <h2>Nieuwe feedback op ${escapeHtml(site)}</h2>
+      <p><strong>Sterren:</strong> ${"★".repeat(rating)}${"☆".repeat(5 - rating)} (${rating}/5)</p>
+      ${comment ? `<p><strong>Opmerking:</strong><br>${escapeHtml(comment)}</p>` : ""}
+      <hr/>
+      <p style="font-size:12px;color:#666">
+        Pagina: ${escapeHtml(path || "-")}<br/>
+        User-Agent: ${escapeHtml(ua || "-")}<br/>
+        Timestamp: ${new Date().toISOString()}
+      </p>
+    </div>
+  `;
+
   try {
-    await resend.emails.send({
-      from: process.env.FEEDBACK_FROM || "feedback@example.com",
-      to: process.env.FEEDBACK_TO || "dev@example.com",
-      subject: `Feedback (${rating} stars)`,
-      text: [
-        `Stars: ${rating}`,
-        comment ? `Comment: ${comment}` : undefined,
-        path ? `Path: ${path}` : undefined,
-        ua ? `User-Agent: ${ua}` : undefined,
-      ]
-        .filter(Boolean)
-        .join("\n"),
+    const { error } = await resend.emails.send({
+      from: "onboarding@resend.dev", // werkt zonder domeinvalidatie
+      to,
+      subject: `⭐ ${rating}/5 feedback binnen op ${site}`,
+      html,
     });
+
+    if (error) return res.status(500).json({ error: String(error) });
+    return res.status(200).json({ ok: true });
   } catch (error: any) {
     return res.status(500).json({ error: error.message || "Failed to send" });
   }
-  res.status(200).json({ ok: true });
+}
+
+function escapeHtml(s?: string) {
+  return (s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }


### PR DESCRIPTION
## Summary
- fix `/api/feedback` to use a safe default sender address and new env var `FEEDBACK_TO_EMAIL`
- improve error handling and add HTML mail body

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b07930b3988330b2546bf250ef399e