### PR TITLE
Add feedback API endpoint and client helper

### DIFF
--- a/Leerdoelengenerator-main/api/feedback-debug.ts
+++ b/Leerdoelengenerator-main/api/feedback-debug.ts
@@ -1,0 +1,12 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default function handler(_req: VercelRequest, res: VercelResponse) {
+  const info = {
+    hasResendKey: !!process.env.RESEND_API_KEY,
+    hasFrom: !!process.env.FEEDBACK_FROM,
+    hasTo: !!process.env.FEEDBACK_TO,
+    nodeEnv: process.env.NODE_ENV,
+  };
+  res.setHeader('Content-Type', 'application/json');
+  res.status(200).json({ ok: true, info });
+}

--- a/Leerdoelengenerator-main/api/feedback-selftest.ts
+++ b/Leerdoelengenerator-main/api/feedback-selftest.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+
 export default function handler(_req: VercelRequest, res: VercelResponse) {
   res.setHeader('Content-Type', 'application/json');
-  res.status(200).send(JSON.stringify({ ok: true, route: '/api/feedback-selftest' }));
+  res.status(200).json({ ok: true, route: '/api/feedback-selftest' });
 }

--- a/Leerdoelengenerator-main/api/feedback-selftest.ts
+++ b/Leerdoelengenerator-main/api/feedback-selftest.ts
@@ -1,0 +1,5 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+export default function handler(_req: VercelRequest, res: VercelResponse) {
+  res.setHeader('Content-Type', 'application/json');
+  res.status(200).send(JSON.stringify({ ok: true, route: '/api/feedback-selftest' }));
+}

--- a/Leerdoelengenerator-main/api/feedback.ts
+++ b/Leerdoelengenerator-main/api/feedback.ts
@@ -1,0 +1,48 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY || '');
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'POST') return res.status(405).json({ ok: false, error: 'Method Not Allowed' });
+
+  try {
+    const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+    const { rating, comment, page, meta } = body || {};
+    if (typeof rating !== 'number' || rating < 1 || rating > 5) {
+      return res.status(400).json({ ok: false, error: 'Invalid rating (1–5 required)' });
+    }
+    const to = process.env.FEEDBACK_TO;
+    const from = process.env.FEEDBACK_FROM;
+    if (!process.env.RESEND_API_KEY || !to || !from) {
+      return res.status(500).json({ ok: false, error: 'Missing env: RESEND_API_KEY, FEEDBACK_TO, FEEDBACK_FROM' });
+    }
+
+    const subject = `Nieuwe feedback (${rating}/5)${page ? ` — ${page}` : ''}`;
+    const html = `
+      <div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif">
+        <h2>Nieuwe feedback</h2>
+        <p><strong>Rating:</strong> ${rating}/5</p>
+        ${comment ? `<p><strong>Commentaar:</strong> ${escapeHtml(comment)}</p>` : ''}
+        ${page ? `<p><strong>Pagina:</strong> ${escapeHtml(page)}</p>` : ''}
+        ${meta ? `<pre style="background:#f6f8fa;padding:12px;border-radius:6px">${escapeHtml(JSON.stringify(meta,null,2))}</pre>` : ''}
+      </div>
+    `;
+
+    const result = await resend.emails.send({ from, to, subject, html });
+    if ((result as any)?.error) return res.status(502).json({ ok: false, error: String((result as any).error) });
+
+    return res.status(200).json({ ok: true });
+  } catch (err: any) {
+    console.error('feedback endpoint error:', err);
+    return res.status(500).json({ ok: false, error: err?.message ?? 'Unknown error' });
+  }
+}
+
+function escapeHtml(s: string) {
+  return s.replace(/[&<>"']/g, (m) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#039;'}[m]!));
+}

--- a/Leerdoelengenerator-main/package.json
+++ b/Leerdoelengenerator-main/package.json
@@ -20,7 +20,7 @@
     "@google/generative-ai": "^0.2.1",
     "zod": "^3.23.8",
     "react-router-dom": "^6.24.0",
-    "resend": "^3.2.0"
+    "resend": "^3.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/Leerdoelengenerator-main/src/components/StarFeedback.tsx
+++ b/Leerdoelengenerator-main/src/components/StarFeedback.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { submitFeedback } from "@/services/feedback";
 
 export default function StarFeedback() {
   const [sending, setSending] = useState(false);
@@ -8,25 +9,17 @@ export default function StarFeedback() {
   const [comment, setComment] = useState<string>("");
   const [stars, setStars] = useState<number>(5);
 
-  async function submitFeedback() {
+  async function handleSubmit() {
     setSending(true);
     setError(null);
     setSuccess(false);
     try {
-      const res = await fetch("/api/feedback", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          stars,
-          comment,
-          path: typeof window !== "undefined" ? window.location.pathname : "",
-          ua: typeof navigator !== "undefined" ? navigator.userAgent : "",
-        }),
-      });
-
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
-
+      await submitFeedback(
+        stars,
+        comment,
+        typeof window !== "undefined" ? window.location.pathname : "",
+        { ua: typeof navigator !== "undefined" ? navigator.userAgent : "" }
+      );
       setSuccess(true);
       setComment("");
     } catch (e: any) {
@@ -63,7 +56,7 @@ export default function StarFeedback() {
       />
 
       <button
-        onClick={submitFeedback}
+        onClick={handleSubmit}
         disabled={sending}
         className="mt-2 rounded bg-black px-3 py-2 text-white disabled:opacity-50"
       >
@@ -75,4 +68,3 @@ export default function StarFeedback() {
     </div>
   );
 }
-

--- a/Leerdoelengenerator-main/src/services/feedback.ts
+++ b/Leerdoelengenerator-main/src/services/feedback.ts
@@ -1,0 +1,13 @@
+export async function submitFeedback(rating: number, comment: string, page?: string, meta?: any) {
+  const res = await fetch('/api/feedback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rating, comment, page, meta }),
+  });
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`;
+    try { const data = await res.json(); if (data?.error) msg += ` – ${data.error}`; } catch {}
+    throw new Error(msg);
+  }
+  return res.json();
+}

--- a/Leerdoelengenerator-main/src/services/feedback.ts
+++ b/Leerdoelengenerator-main/src/services/feedback.ts
@@ -4,10 +4,15 @@ export async function submitFeedback(rating: number, comment: string, page?: str
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ rating, comment, page, meta }),
   });
-  if (!res.ok) {
-    let msg = `HTTP ${res.status}`;
-    try { const data = await res.json(); if (data?.error) msg += ` – ${data.error}`; } catch {}
-    throw new Error(msg);
-  }
-  return res.json();
+
+  let data: any;
+  let msg = `HTTP ${res.status}`;
+  try {
+    data = await res.json();
+    if (data?.error) msg += ` – ${data.error}`;
+    if (data?.code) msg += ` [${data.code}]`;
+  } catch {}
+
+  if (!res.ok) throw new Error(msg);
+  return data;
 }


### PR DESCRIPTION
## Summary
- add `/api/feedback` endpoint sending rating/comments via Resend
- expose `/api/feedback-selftest` healthcheck route
- provide client `submitFeedback` helper and update star feedback component
- update Resend dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b83b80529c8330a4ea97217edb3c88