### PR TITLE
Add goal feedback modal and API goal field

### DIFF
--- a/Leerdoelengenerator-main/api/feedback.ts
+++ b/Leerdoelengenerator-main/api/feedback.ts
@@ -15,6 +15,7 @@ export default async function handler(req: Request): Promise<Response> {
     const body = await req.json().catch(() => ({}));
     const stars = Number(body?.stars);
     const comment = (body?.comment ?? "").toString().slice(0, 2000);
+    const goal = (body?.goal ?? "").toString().slice(0, 1600);
     const page = (body?.page ?? "").toString().slice(0, 500);
     const email = (body?.email ?? "").toString().slice(0, 320);
     const ua = (body?.ua ?? "").toString().slice(0, 500);
@@ -42,10 +43,11 @@ export default async function handler(req: Request): Promise<Response> {
       body: JSON.stringify({
         from: RESEND_FROM,
         to: FEEDBACK_TO,
-        subject: `Nieuwe feedback (${stars}⭐)`,
+        subject: `Beoordeling leerdoel (${stars}⭐)`,
         text: [
           `Sterren: ${stars}`,
           `Opmerking: ${comment || "-"}`,
+          `Leerdoel: ${goal || "-"}`,
           `Pagina: ${page || "-"}`,
           `Email (optioneel): ${email || "-"}`,
           `User-Agent: ${ua || "-"}`,

--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -34,6 +34,7 @@ import FeedbackWidget from "./components/FeedbackWidget";
 import { getSuggestions } from "./data/suggestions";
 import { inferGoalOrientation, mapEducationLevel } from "./utils/suggestionHelpers";
 import type { SuggestionBundle } from "./types/learning";
+import GoalFeedbackModal from "./components/GoalFeedbackModal";
 
 /* --------------------- Helpers: opslag + delen --------------------- */
 const STORAGE_KEY = "ld-app-state-v2";
@@ -219,6 +220,7 @@ function App() {
   const [showQualityChecker, setShowQualityChecker] = useState(false);
   const levelKey: LevelKey = toLevelKey(formData.context);
   const [showEducationGuidance, setShowEducationGuidance] = useState(false);
+  const [showGoalFeedback, setShowGoalFeedback] = useState(false);
   const [generationSource, setGenerationSource] = useState<GenerationSource>(null); // NIEUW: bron van de laatste generatie
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -416,6 +418,7 @@ function App() {
     }
 
         setOutput(adjusted);
+        setShowGoalFeedback(true);
         setGenerationSource("gemini");
         console.log("[AI-check] Gebruik: Gemini (AI)");
 
@@ -441,6 +444,7 @@ function App() {
           formData.context,
         );
         setOutput(aiOutput);
+        setShowGoalFeedback(true);
         setGenerationSource("fallback");
         console.log("[AI-check] Gebruik: fallback (geen Gemini)");
 
@@ -469,6 +473,7 @@ function App() {
         formData.context,
       );
       setOutput(fallback);
+      setShowGoalFeedback(true);
       setGenerationSource("fallback");
 
       setAiGoTags(
@@ -1457,6 +1462,11 @@ function App() {
       {showKDImport && <KDImport onKDImported={handleKDImported} onClose={() => setShowKDImport(false)} />}
       {showSavedObjectives && <SavedObjectives onLoadObjective={loadObjective} onClose={() => setShowSavedObjectives(false)} />}
       {showTemplateLibrary && <TemplateLibrary onUseTemplate={useTemplate} onClose={() => setShowTemplateLibrary(false)} />}
+      <GoalFeedbackModal
+        open={showGoalFeedback}
+        onClose={() => setShowGoalFeedback(false)}
+        goalText={output?.newObjective ?? ""}
+      />
 
       {/* Click outside to close export menu */}
       {showExportMenu && <div className="fixed inset-0 z-5" onClick={() => setShowExportMenu(false)} />}

--- a/Leerdoelengenerator-main/src/components/GoalFeedbackModal.tsx
+++ b/Leerdoelengenerator-main/src/components/GoalFeedbackModal.tsx
@@ -1,0 +1,86 @@
+"use client";
+import { useState } from "react";
+import StarRating from "./StarRating";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  goalText: string;        // het net gegenereerde leerdoel
+};
+
+export default function GoalFeedbackModal({ open, onClose, goalText }: Props) {
+  const [stars, setStars] = useState(0);
+  const [comment, setComment] = useState("");
+  const [status, setStatus] = useState<"idle"|"sending"|"ok"|"error">("idle");
+  const [err, setErr] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  async function send() {
+    if (stars < 1) { setErr("Kies eerst een aantal sterren."); return; }
+    setErr(null); setStatus("sending");
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          stars,
+          comment,
+          goal: goalText,                                   // ⬅️ meegeven aan API
+          page: typeof window !== "undefined" ? window.location.href : "",
+          ua: typeof navigator !== "undefined" ? navigator.userAgent : "",
+          hp: "",
+        }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setStatus("ok");
+      setTimeout(onClose, 1200); // zacht sluiten
+    } catch (e) {
+      setStatus("error");
+      setErr("Verzenden mislukt. Probeer het later nog eens.");
+      console.error(e);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] grid place-items-center bg-black/40 p-4">
+      <div className="w-full max-w-xl rounded-2xl bg-white p-5 shadow-xl">
+        <div className="flex items-start justify-between gap-4">
+          <h3 className="text-lg font-semibold">Hoe beoordeel je dit leerdoel?</h3>
+          <button onClick={onClose} className="rounded-md p-1 text-gray-500 hover:bg-gray-100">✕</button>
+        </div>
+
+        <div className="mt-3 rounded-xl border bg-gray-50 p-3 text-sm">
+          <p className="whitespace-pre-wrap">{goalText}</p>
+        </div>
+
+        <div className="mt-4">
+          <StarRating value={stars} onChange={setStars} />
+        </div>
+
+        <textarea
+          className="mt-3 w-full rounded-lg border p-2"
+          rows={3}
+          placeholder="Optioneel: licht je beoordeling kort toe…"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          maxLength={2000}
+        />
+
+        {err && <p className="mt-2 text-sm text-red-600">{err}</p>}
+        {status === "ok" && <p className="mt-2 text-sm text-green-700">Bedankt! 🎉</p>}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button onClick={onClose} className="rounded-lg px-4 py-2 text-gray-700 hover:bg-gray-100">Later</button>
+          <button
+            onClick={send}
+            disabled={status === "sending"}
+            className="rounded-lg bg-black px-4 py-2 text-white disabled:opacity-50"
+          >
+            {status === "sending" ? "Versturen…" : "Verstuur"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/components/StarRating.tsx
+++ b/Leerdoelengenerator-main/src/components/StarRating.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useId } from "react";
+
+type Props = {
+  value: number;
+  onChange: (n: number) => void;
+  max?: number;          // default 5
+  sizeClass?: string;    // bijv. "text-2xl"
+};
+
+export default function StarRating({ value, onChange, max = 5, sizeClass = "text-2xl" }: Props) {
+  const gid = useId();
+  return (
+    <div className="flex items-center gap-1" role="radiogroup" aria-labelledby={`${gid}-label`}>
+      {Array.from({ length: max }, (_, i) => i + 1).map((n) => (
+        <button
+          key={n}
+          type="button"
+          onClick={() => onChange(n)}
+          aria-label={`${n} ster${n > 1 ? "ren" : ""}`}
+          aria-pressed={value >= n}
+          className={`${sizeClass} leading-none transition-transform hover:scale-110
+                      ${value >= n ? "text-yellow-400" : "text-gray-300"}`}
+          title={`${n} ster${n > 1 ? "ren" : ""}`}
+        >
+          ★
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- capture learning goal in feedback API and include in email
- introduce reusable `StarRating` component and feedback modal
- show goal feedback modal automatically after goal generation

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b87eb67cc083308a37861fe31e1af4