### PR TITLE
Style inline feedback block with brand colors

### DIFF
--- a/Leerdoelengenerator-main/src/components/FeedbackInline.tsx
+++ b/Leerdoelengenerator-main/src/components/FeedbackInline.tsx
@@ -1,19 +1,53 @@
-// components/FeedbackInline.tsx
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 type Props = {
   defaultStars?: number;
   path?: string;
+  className?: string;
+  title?: string;
+  buttonLabel?: string;
+  placeholder?: string;
 };
 
-export default function FeedbackInline({ defaultStars = 5, path }: Props) {
+export default function FeedbackInline({
+  defaultStars = 5,
+  path,
+  className = "",
+  title = "Hoe beoordeel je deze gegenereerde leerdoelen?",
+  buttonLabel = "Verstuur feedback",
+  placeholder = "(optioneel) licht je beoordeling toe…",
+}: Props) {
   const [stars, setStars] = useState<number>(defaultStars);
+  const [hover, setHover] = useState<number | null>(null);
   const [comment, setComment] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+
+  const active = hover ?? stars;
+
+  const starButtons = useMemo(
+    () =>
+      [1, 2, 3, 4, 5].map((i) => (
+        <button
+          key={i}
+          type="button"
+          aria-label={`${i} ster`}
+          onMouseEnter={() => setHover(i)}
+          onMouseLeave={() => setHover(null)}
+          onFocus={() => setHover(i)}
+          onBlur={() => setHover(null)}
+          onClick={() => setStars(i)}
+          className="size-7 md:size-8"
+          title={`${i}/5`}
+        >
+          <Star filled={i <= active} />
+        </button>
+      )),
+    [active]
+  );
 
   async function submitFeedback() {
     setSending(true);
@@ -44,53 +78,87 @@ export default function FeedbackInline({ defaultStars = 5, path }: Props) {
   return (
     <section
       aria-labelledby="feedback-title"
-      className="mt-6 rounded-xl border border-neutral-200 bg-white/60 p-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/40 dark:border-neutral-800 dark:bg-neutral-900/60"
+      className={[
+        "mt-6 rounded-2xl border p-4 md:p-5 shadow-sm",
+        "bg-[var(--brand-card)] border-[var(--brand-border)] text-[var(--brand-text)]",
+        "backdrop-blur supports-[backdrop-filter]:bg-[color:var(--brand-card)]",
+        className,
+      ].join(" ")}
     >
-      <h3 id="feedback-title" className="mb-2 text-sm font-semibold text-neutral-700 dark:text-neutral-200">
-        Hoe beoordeel je deze gegenereerde leerdoelen?
+      <h3
+        id="feedback-title"
+        className="mb-3 text-base md:text-lg font-semibold"
+        style={{ color: "var(--brand-text)" }}
+      >
+        {title}
       </h3>
 
       {/* Stars */}
-      <div className="mb-2 flex items-center gap-1">
-        {[1, 2, 3, 4, 5].map((i) => (
-          <button
-            key={i}
-            type="button"
-            aria-label={`${i} ster`}
-            onClick={() => setStars(i)}
-            className="text-2xl leading-none"
-            title={`${i}/5`}
-          >
-            {i <= stars ? "★" : "☆"}
-          </button>
-        ))}
-        <span className="ml-2 text-sm text-neutral-500">{stars}/5</span>
+      <div className="mb-2 flex items-center gap-1.5">{starButtons}</div>
+      <div className="mb-3 text-xs md:text-sm" style={{ color: "var(--brand-muted)" }}>
+        {active}/5
       </div>
 
       {/* Comment */}
-      <label className="block text-xs text-neutral-500 dark:text-neutral-400 mb-1">
-        (optioneel) licht je beoordeling toe…
+      <label className="block text-xs mb-1" style={{ color: "var(--brand-muted)" }}>
+        {placeholder}
       </label>
       <textarea
         value={comment}
         onChange={(e) => setComment(e.target.value)}
         rows={3}
-        className="w-full resize-y rounded-lg border border-neutral-300 bg-white p-2 text-sm outline-none focus:ring-2 focus:ring-black/10 dark:border-neutral-700 dark:bg-neutral-900"
+        className="w-full resize-y rounded-xl border bg-transparent p-3 text-sm outline-none focus:ring-2"
+        style={{
+          borderColor: "var(--brand-border)",
+          color: "var(--brand-text)",
+          boxShadow: "none",
+        }}
       />
 
       {/* Actions / Messages */}
-      <div className="mt-3 flex items-center gap-3">
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
         <button
           onClick={submitFeedback}
           disabled={sending}
-          className="rounded-lg bg-black px-4 py-2 text-white disabled:opacity-60 dark:bg-white dark:text-black"
+          className="rounded-xl px-4 py-2 text-sm font-medium disabled:opacity-60"
+          style={{
+            background: "var(--brand-btn-bg)",
+            color: "var(--brand-btn-text)",
+          }}
+          onMouseEnter={(e) => ((e.currentTarget.style.background as any) = "var(--brand-btn-bg-hover)")}
+          onMouseLeave={(e) => ((e.currentTarget.style.background as any) = "var(--brand-btn-bg)")}
         >
-          {sending ? "Versturen…" : "Verstuur feedback"}
+          {sending ? "Versturen…" : buttonLabel}
         </button>
-        {error && <p className="text-sm text-red-600">⚠ {error}</p>}
-        {success && <p className="text-sm text-green-600">Bedankt! Je feedback is verzonden.</p>}
+
+        {error && (
+          <p className="text-sm" style={{ color: "var(--brand-error)" }}>
+            ⚠ {error}
+          </p>
+        )}
+        {success && (
+          <p className="text-sm" style={{ color: "var(--brand-success)" }}>
+            Bedankt! Je feedback is verzonden.
+          </p>
+        )}
       </div>
     </section>
   );
 }
 
+/** Gele ster (SVG), vult met --brand-accent bij filled=true */
+function Star({ filled }: { filled: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="inline-block"
+      aria-hidden="true"
+      style={{ fill: filled ? "var(--brand-accent)" : "transparent", stroke: "var(--brand-accent)" }}
+    >
+      <path
+        strokeWidth="1.5"
+        d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+      />
+    </svg>
+  );
+}

--- a/Leerdoelengenerator-main/src/main.tsx
+++ b/Leerdoelengenerator-main/src/main.tsx
@@ -7,6 +7,7 @@ import GlossaryPage from '@/pages/begrippen';
 import Layout from '@/components/Layout';
 import RouteTracker from '@/components/RouteTracker';
 import CookieBanner from '@/components/CookieBanner';
+import '@/styles/brand.css';
 import './index.css';
 
 const rootElement = document.getElementById('root')!;

--- a/Leerdoelengenerator-main/src/styles/brand.css
+++ b/Leerdoelengenerator-main/src/styles/brand.css
@@ -1,0 +1,28 @@
+/* styles/brand.css */
+/* Pas de kleuren hier aan je huisstijl aan */
+:root{
+  --brand-bg:            #fffaf5; /* pagina-achtergrond (fallback) */
+  --brand-card:          #ffffff; /* kaart-achtergrond */
+  --brand-border:        #e5e7eb; /* kaart-rand */
+  --brand-text:          #111827; /* primaire tekst */
+  --brand-muted:         #6b7280; /* secundaire tekst */
+  --brand-accent:        #facc15; /* ACCENT (sterren/hover)  = geel */
+  --brand-btn-bg:        #111827; /* knop bg */
+  --brand-btn-text:      #ffffff; /* knop tekst */
+  --brand-btn-bg-hover:  #000000; /* knop hover */
+  --brand-success:       #16a34a; /* succesmelding */
+  --brand-error:         #dc2626; /* foutmelding */
+}
+
+@media (prefers-color-scheme: dark){
+  :root{
+    --brand-bg:           #0b0b0b;
+    --brand-card:         #101010;
+    --brand-border:       #262626;
+    --brand-text:         #fafafa;
+    --brand-muted:        #a3a3a3;
+    --brand-btn-bg:       #fafafa;
+    --brand-btn-text:     #0b0b0b;
+    --brand-btn-bg-hover: #ffffff;
+  }
+}


### PR DESCRIPTION
## Summary
- add brand color variables for consistent styling
- style inline feedback component with yellow SVG stars
- import brand theme into application entry point

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b88797af4c833098fa06def8ade335