### PR TITLE
Ensure baan 2 goals always allow AI usage

### DIFF
--- a/Leerdoelengenerator-main/src/lib/twoLane.ts
+++ b/Leerdoelengenerator-main/src/lib/twoLane.ts
@@ -28,8 +28,13 @@ const DEFAULT_ETHICS = ['privacy', 'bias', 'bronvermelding'];
  */
 export function generateTwoLaneOutput(ctx: LearningObjectiveContext): TwoLaneOutput {
   const lane = ctx.lane === 'baan2' ? 'baan2' : 'baan1';
-  const aiUsage: 'verboden' | 'beperkt' | 'toegestaan' | 'verplicht' =
-    ctx.ai_usage ?? (lane === 'baan2' ? 'toegestaan' : 'beperkt');
+  let aiUsage: 'verboden' | 'beperkt' | 'toegestaan' | 'verplicht';
+  if (lane === 'baan2') {
+    // In baan 2 mag AI altijd worden ingezet; alleen 'verplicht' blijft expliciet verplicht
+    aiUsage = ctx.ai_usage === 'verplicht' ? 'verplicht' : 'toegestaan';
+  } else {
+    aiUsage = ctx.ai_usage ?? 'beperkt';
+  }
 
   if (lane === 'baan1') {
     const objective = `Na afloop van deze les kan de student, zonder AI, ${ctx.original}`;

--- a/Leerdoelengenerator-main/src/tests/twoLane.test.ts
+++ b/Leerdoelengenerator-main/src/tests/twoLane.test.ts
@@ -33,6 +33,21 @@ describe('Two-Lane generator', () => {
     expect(out.rubric).toContain('AI-geletterdheid (keuze, promptkwaliteit, evaluatie)');
   });
 
+  it('Baan 2 negeert expliciet AI-verbod en staat gebruik toe', () => {
+    const ctx: LearningObjectiveContext = {
+      original: 'eenvoudige wondverzorging uitvoeren bij een gesimuleerde cliënt, conform richtlijnen',
+      education: 'MBO',
+      level: 'Niveau 2',
+      domain: 'Zorg',
+      lane: 'baan2',
+      ai_usage: 'verboden',
+    } as any;
+    const out = generateTwoLaneOutput(ctx);
+    expect(out.aiUsage).toBe('toegestaan');
+    expect(out.objective).toContain('toegestaan');
+    expect(out.objective).not.toContain('verboden');
+  });
+
   it('Business-domein met verplicht AI-gebruik vermeldt verplicht in doel', () => {
     const ctx: LearningObjectiveContext = {
       original: 'een financieel plan opstellen voor een start-up',


### PR DESCRIPTION
## Summary
- Enforce that lane 2 (baan 2) objectives never forbid AI; AI use defaults to allowed and only remains "verplicht" when explicitly required
- Add test confirming AI bans are ignored in baan 2

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cbaf097083309fda79733ba01e7d