### PR TITLE
feat: scaffold funderend kerndoelen data and sector components

### DIFF
--- a/Leerdoelengenerator-main/data/standards/README.md
+++ b/Leerdoelengenerator-main/data/standards/README.md
@@ -1,0 +1,13 @@
+# SLO 2025 Kerndoelen datasets
+
+Deze map bevat strikt gestructureerde en versieerbare JSON-bestanden met de officiële SLO-kerndoelen voor Burgerschap en Digitale geletterdheid. Vul bij uitbreiding altijd de exacte kernzinnen en subdoelen in zoals gepubliceerd door SLO.
+
+## Structuur
+
+```
+slo_2025/
+  bg_funderend.v1.json  # Burgerschap voor PO, SO, VO-onderbouw en VSO
+  dg_funderend.v1.json  # Digitale geletterdheid voor PO, SO, VO-onderbouw en VSO
+```
+
+Alle bestanden volgen `src/lib/standards/validators/slo.schema.json` voor validatie.

--- a/Leerdoelengenerator-main/data/standards/slo_2025/bg_funderend.v1.json
+++ b/Leerdoelengenerator-main/data/standards/slo_2025/bg_funderend.v1.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "BG-VO-02",
+    "sectors": ["VO_ONDERBOUW", "VSO", "PO", "SO"],
+    "leergebied": "BURGERSCHAP",
+    "kernzin": "<exacte SLO-kernzin>",
+    "subdoelen": [
+      { "code": "BG-VO-02-a", "tekst": "<exact subdoel>" }
+    ],
+    "status": "definitieve_concepten_2025",
+    "bron": { "doc": "SLO-2025", "ref": "Burgerschap: secties PO/SO/VO-onderbouw/VSO" }
+  }
+]

--- a/Leerdoelengenerator-main/data/standards/slo_2025/dg_funderend.v1.json
+++ b/Leerdoelengenerator-main/data/standards/slo_2025/dg_funderend.v1.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "DG-PO-01",
+    "sectors": ["PO", "SO", "VO_ONDERBOUW", "VSO"],
+    "leergebied": "DG",
+    "kernzin": "<exacte SLO-kernzin>",
+    "subdoelen": [
+      { "code": "DG-PO-01-a", "tekst": "<exact subdoel>" }
+    ],
+    "status": "definitieve_concepten_2025",
+    "bron": { "doc": "SLO-2025", "ref": "DG: Kerndoelen PO/SO en VO-onderbouw/VSO" }
+  }
+]

--- a/Leerdoelengenerator-main/src/constants/sector.ts
+++ b/Leerdoelengenerator-main/src/constants/sector.ts
@@ -1,0 +1,11 @@
+export const SECTORS = [
+  'PO',
+  'SO',
+  'VO_ONDERBOUW',
+  'VSO',
+  'MBO',
+  'HBO',
+  'WO',
+] as const;
+
+export type Sector = typeof SECTORS[number];

--- a/Leerdoelengenerator-main/src/features/ai-banen/AiBaanToggle.tsx
+++ b/Leerdoelengenerator-main/src/features/ai-banen/AiBaanToggle.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { AiBaanSettings } from '../../lib/standards/types';
+
+interface Props {
+  value: AiBaanSettings;
+  onChange: (value: AiBaanSettings) => void;
+}
+
+export function AiBaanToggle({ value, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="inline-flex items-center gap-2">
+        <input
+          type="radio"
+          name="ai-baan"
+          checked={value.baan === 1}
+          onChange={() => onChange({ ...value, baan: 1 })}
+        />
+        <span>Baan 1</span>
+      </label>
+      <label className="inline-flex items-center gap-2">
+        <input
+          type="radio"
+          name="ai-baan"
+          checked={value.baan === 2}
+          onChange={() => onChange({ ...value, baan: 2, transparantie: true, procesbewijzen: true })}
+        />
+        <span>Baan 2</span>
+      </label>
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/features/ai-banen/applyAiBaanRules.ts
+++ b/Leerdoelengenerator-main/src/features/ai-banen/applyAiBaanRules.ts
@@ -1,0 +1,19 @@
+import type { AiBaanSettings } from '../../lib/standards/types';
+
+interface Section {
+  content: string[];
+}
+
+export function applyAiBaanRules(sections: Section, settings: AiBaanSettings): Section {
+  if (settings.baan === 2) {
+    return {
+      content: [
+        ...sections.content,
+        'Transparantie: documenteer wat, wanneer en hoe AI is gebruikt.',
+        'Procesbewijzen: bewaar versies en logboeken.',
+        'Reflectie: beschrijf de rol van AI en mogelijke bias.',
+      ],
+    };
+  }
+  return sections;
+}

--- a/Leerdoelengenerator-main/src/features/kerndoelen/KerndoelSelector.tsx
+++ b/Leerdoelengenerator-main/src/features/kerndoelen/KerndoelSelector.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { Kerndoel } from '../../lib/standards/types';
+
+interface Props {
+  kerndoelen: Kerndoel[];
+  selected: string[];
+  toggle: (id: string) => void;
+}
+
+export function KerndoelSelector({ kerndoelen, selected, toggle }: Props) {
+  return (
+    <div className="flex flex-col gap-2">
+      {kerndoelen.map((kd) => (
+        <label key={kd.id} className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={selected.includes(kd.id)}
+            onChange={() => toggle(kd.id)}
+          />
+          <span>{kd.kernzin}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/features/kerndoelen/mappings/slo-funderend.ts
+++ b/Leerdoelengenerator-main/src/features/kerndoelen/mappings/slo-funderend.ts
@@ -1,0 +1,15 @@
+import type { Kerndoel } from '../../../lib/standards/types';
+
+export interface FunderendOutput {
+  kerndoel: Kerndoel;
+  didactischeDoelen: string[];
+  werkvormen: string[];
+}
+
+export function mapKerndoel(kerndoel: Kerndoel): FunderendOutput {
+  return {
+    kerndoel,
+    didactischeDoelen: [],
+    werkvormen: [],
+  };
+}

--- a/Leerdoelengenerator-main/src/features/kerndoelen/useKerndoelen.ts
+++ b/Leerdoelengenerator-main/src/features/kerndoelen/useKerndoelen.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+import { loadKerndoelen } from '../../lib/standards';
+import type { Kerndoel, Leergebied } from '../../lib/standards/types';
+
+export function useKerndoelen(file: string, leergebied?: Leergebied) {
+  const [kerndoelen] = useState<Kerndoel[]>(() => loadKerndoelen(file));
+  const list = leergebied
+    ? kerndoelen.filter((k) => k.leergebied === leergebied)
+    : kerndoelen;
+  return { kerndoelen: list };
+}

--- a/Leerdoelengenerator-main/src/features/sector/SectorSelector.tsx
+++ b/Leerdoelengenerator-main/src/features/sector/SectorSelector.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { SECTORS, Sector } from '../../constants/sector';
+
+interface Props {
+  value: Sector;
+  onChange: (sector: Sector) => void;
+}
+
+export function SectorSelector({ value, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-2">
+      {SECTORS.map((s) => (
+        <label key={s} className="inline-flex items-center gap-2">
+          <input
+            type="radio"
+            name="sector"
+            value={s}
+            checked={value === s}
+            onChange={() => onChange(s)}
+          />
+          <span>{s}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/features/sector/useSector.ts
+++ b/Leerdoelengenerator-main/src/features/sector/useSector.ts
@@ -1,0 +1,7 @@
+import { useState } from 'react';
+import type { Sector } from '../../constants/sector';
+
+export function useSector(initial: Sector = 'MBO') {
+  const [sector, setSector] = useState<Sector>(initial);
+  return { sector, setSector };
+}

--- a/Leerdoelengenerator-main/src/features/tos/TosOptions.tsx
+++ b/Leerdoelengenerator-main/src/features/tos/TosOptions.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { TosSupport } from '../../lib/standards/types';
+
+interface Props {
+  value: TosSupport;
+  onChange: (value: TosSupport) => void;
+}
+
+export function TosOptions({ value, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="inline-flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={value.spraakNaarTekst}
+          onChange={(e) => onChange({ ...value, spraakNaarTekst: e.target.checked })}
+        />
+        <span>Spraak naar tekst</span>
+      </label>
+      <label className="inline-flex items-center gap-2">
+        <span>Taalvereenvoudiging</span>
+        <select
+          value={value.taalvereenvoudiging}
+          onChange={(e) => onChange({ ...value, taalvereenvoudiging: e.target.value as any })}
+        >
+          <option value="uit">Uit</option>
+          <option value="licht">Licht</option>
+          <option value="sterk">Sterk</option>
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/features/tos/applyTosSupports.ts
+++ b/Leerdoelengenerator-main/src/features/tos/applyTosSupports.ts
@@ -1,0 +1,10 @@
+import type { TosSupport } from '../../lib/standards/types';
+
+export function applyTosSupports<T extends { text: string }>(input: T, tos: TosSupport): T {
+  let text = input.text;
+  if (tos.taalvereenvoudiging !== 'uit') {
+    // placeholder for simplification logic
+    text = text.replace(/\w{10,}/g, (w) => w.slice(0, 10));
+  }
+  return { ...input, text };
+}

--- a/Leerdoelengenerator-main/src/lib/standards/index.ts
+++ b/Leerdoelengenerator-main/src/lib/standards/index.ts
@@ -1,0 +1,9 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Kerndoel } from './types';
+
+export function loadKerndoelen(file: string): Kerndoel[] {
+  const filePath = path.resolve(process.cwd(), 'data/standards', file);
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return JSON.parse(raw) as Kerndoel[];
+}

--- a/Leerdoelengenerator-main/src/lib/standards/types.ts
+++ b/Leerdoelengenerator-main/src/lib/standards/types.ts
@@ -1,0 +1,35 @@
+export type Sector =
+  | 'PO'
+  | 'SO'
+  | 'VO_ONDERBOUW'
+  | 'VSO'
+  | 'MBO'
+  | 'HBO'
+  | 'WO';
+
+export type Leergebied = 'BURGERSCHAP' | 'DG';
+
+export interface Kerndoel {
+  id: string;
+  sectors: Sector[];
+  leergebied: Leergebied;
+  kernzin: string;
+  subdoelen: { code: string; tekst: string }[];
+  toelichting?: string;
+  status: 'definitieve_concepten_2025';
+  bron: { doc: 'SLO-2025'; ref: string };
+}
+
+export interface AiBaanSettings {
+  baan: 1 | 2;
+  transparantie: boolean;
+  procesbewijzen: boolean;
+}
+
+export interface TosSupport {
+  spraakNaarTekst: boolean;
+  taalvereenvoudiging: 'uit' | 'licht' | 'sterk';
+  visueleHints: boolean;
+  woordenschatBank: boolean;
+  leesniveau: 'A1' | 'A2' | '1F' | '2F';
+}

--- a/Leerdoelengenerator-main/src/lib/standards/validators/slo.schema.json
+++ b/Leerdoelengenerator-main/src/lib/standards/validators/slo.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "sectors", "leergebied", "kernzin", "subdoelen", "status", "bron"],
+    "properties": {
+      "id": { "type": "string" },
+      "sectors": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "leergebied": { "type": "string" },
+      "kernzin": { "type": "string" },
+      "subdoelen": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["code", "tekst"],
+          "properties": {
+            "code": { "type": "string" },
+            "tekst": { "type": "string" }
+          }
+        }
+      },
+      "toelichting": { "type": "string" },
+      "status": { "const": "definitieve_concepten_2025" },
+      "bron": {
+        "type": "object",
+        "required": ["doc", "ref"],
+        "properties": {
+          "doc": { "const": "SLO-2025" },
+          "ref": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/Leerdoelengenerator-main/tests/validators/slo.schema.test.ts
+++ b/Leerdoelengenerator-main/tests/validators/slo.schema.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Ajv from 'ajv';
+import schema from '../../src/lib/standards/validators/slo.schema.json';
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(schema as any);
+
+function load(file: string) {
+  const p = join(process.cwd(), 'data/standards/slo_2025', file);
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+describe('SLO kerndoel datasets', () => {
+  for (const file of ['bg_funderend.v1.json', 'dg_funderend.v1.json']) {
+    it(`validates ${file}`, () => {
+      const data = load(file);
+      const valid = validate(data);
+      if (!valid) {
+        console.error(validate.errors);
+      }
+      expect(valid).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add SLO 2025 kerndoelen datasets for Burgerschap and Digitale geletterdheid
- define sector constants and TypeScript types for kerndoelen, TOS, and AI-banen
- scaffold feature hooks and components for sector selection, kerndoel selection, TOS options, and AI lane rules

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c41478ceb08330953dfc221f65a917