### PR TITLE
feat(funderend+vo): enable VO(onderbouw)+VSO kerndoelen & add VO-bovenbouw (eindtermen) mode

### DIFF
--- a/Leerdoelengenerator-main/data/standards/slo_2025/bg_funderend.v1.json
+++ b/Leerdoelengenerator-main/data/standards/slo_2025/bg_funderend.v1.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "BG-VO-02",
-    "sectors": ["VO_ONDERBOUW", "VSO", "PO", "SO"],
+    "sectors": ["PO", "SO", "VO", "VSO"],
     "leergebied": "BURGERSCHAP",
     "kernzin": "<exacte SLO-kernzin>",
     "subdoelen": [

--- a/Leerdoelengenerator-main/data/standards/slo_2025/dg_funderend.v1.json
+++ b/Leerdoelengenerator-main/data/standards/slo_2025/dg_funderend.v1.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "DG-PO-01",
-    "sectors": ["PO", "SO", "VO_ONDERBOUW", "VSO"],
+    "sectors": ["PO", "SO", "VO", "VSO"],
     "leergebied": "DG",
     "kernzin": "<exacte SLO-kernzin>",
     "subdoelen": [

--- a/Leerdoelengenerator-main/src/config.ts
+++ b/Leerdoelengenerator-main/src/config.ts
@@ -1,4 +1,5 @@
 export const feature = {
   aiReadyGoalsV2: import.meta.env.VITE_FEATURE_AI_READY_GOALS_V2 === "true",
+  sloFunderend: import.meta.env.VITE_FEATURE_SLO_KERNDOELEN_FUNDEREND === 'true',
 };
 

--- a/Leerdoelengenerator-main/src/constants/sector.ts
+++ b/Leerdoelengenerator-main/src/constants/sector.ts
@@ -1,7 +1,7 @@
 export const SECTORS = [
   'PO',
   'SO',
-  'VO_ONDERBOUW',
+  'VO',
   'VSO',
   'MBO',
   'HBO',

--- a/Leerdoelengenerator-main/src/features/ai-banen/applyAiBaanRules.ts
+++ b/Leerdoelengenerator-main/src/features/ai-banen/applyAiBaanRules.ts
@@ -1,10 +1,12 @@
 import type { AiBaanSettings } from '../../lib/standards/types';
+import { track } from '../../services/telemetry';
 
 interface Section {
   content: string[];
 }
 
 export function applyAiBaanRules(sections: Section, settings: AiBaanSettings): Section {
+  track('ai_baan_selected', { baan: settings.baan });
   if (settings.baan === 2) {
     return {
       content: [

--- a/Leerdoelengenerator-main/src/features/examenprogramma/VoBovenbouwForm.tsx
+++ b/Leerdoelengenerator-main/src/features/examenprogramma/VoBovenbouwForm.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+
+interface FormValues {
+  vak: string;
+  niveau: 'havo' | 'vwo';
+  cohort?: string;
+  eindtermen: string;
+}
+
+interface Props {
+  onSubmit: (vals: FormValues) => void;
+}
+
+export function VoBovenbouwForm({ onSubmit }: Props) {
+  const [vak, setVak] = useState('');
+  const [niveau, setNiveau] = useState<'havo' | 'vwo'>('havo');
+  const [cohort, setCohort] = useState('');
+  const [eindtermen, setEindtermen] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!eindtermen.trim()) {
+      alert('Voer minstens één eindterm in.');
+      return;
+    }
+    onSubmit({ vak, niveau, cohort: cohort || undefined, eindtermen });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <input
+        value={vak}
+        onChange={(e) => setVak(e.target.value)}
+        placeholder="Vak"
+        required
+      />
+      <div className="flex gap-4">
+        {(['havo', 'vwo'] as const).map((n) => (
+          <label key={n} className="inline-flex items-center gap-2">
+            <input
+              type="radio"
+              name="niveau"
+              value={n}
+              checked={niveau === n}
+              onChange={() => setNiveau(n)}
+            />
+            <span>{n}</span>
+          </label>
+        ))}
+      </div>
+      <input
+        value={cohort}
+        onChange={(e) => setCohort(e.target.value)}
+        placeholder="Cohort/syllabus-jaar (optioneel)"
+      />
+      <textarea
+        value={eindtermen}
+        onChange={(e) => setEindtermen(e.target.value)}
+        placeholder="Plak exacte eindtermen; we herschrijven de bron niet."
+        required
+      />
+      <button type="submit" className="btn">
+        Genereer
+      </button>
+    </form>
+  );
+}

--- a/Leerdoelengenerator-main/src/features/examenprogramma/generateFromEindtermen.ts
+++ b/Leerdoelengenerator-main/src/features/examenprogramma/generateFromEindtermen.ts
@@ -1,0 +1,55 @@
+import type { AiBaanSettings } from '../../lib/standards/types';
+import { applyAiBaanRules } from '../ai-banen/applyAiBaanRules';
+import { track } from '../../services/telemetry';
+
+export interface EindtermInput {
+  vak: string;
+  niveau: 'havo' | 'vwo';
+  cohort?: string;
+  eindtermen: string;
+}
+
+export interface Section {
+  title: string;
+  content: string[];
+}
+
+export interface VoBovenbouwOutput {
+  A: Section; // Eindterm-bron
+  B: Section; // Didactische leeruitkomsten
+  C: Section; // Werkvormen
+  D: Section; // Beoordeling
+  E: Section; // Waarden/Privacy
+}
+
+export function generateFromEindtermen(
+  input: EindtermInput,
+  settings: AiBaanSettings
+): VoBovenbouwOutput {
+  const sectionA: Section = {
+    title: 'Eindterm-bron',
+    content: input.eindtermen.split(/\n+/).filter((l) => l.trim().length > 0),
+  };
+
+  const sectionB: Section = {
+    title: 'Didactische leeruitkomsten',
+    content: [],
+  };
+
+  let sectionC: Section = { title: 'Werkvormen', content: [] };
+  sectionC = applyAiBaanRules(sectionC, settings);
+
+  const sectionD: Section = {
+    title: 'Beoordeling',
+    content: ['CE/SE-koppeling', 'Observatiepunten', 'Verantwoording + procesbewijs'],
+  };
+
+  const sectionE: Section = {
+    title: 'Waarden/Privacy',
+    content: ['Rechtvaardigheid, menselijkheid en autonomie; raadpleeg instellingsbeleid.'],
+  };
+
+  const output = { A: sectionA, B: sectionB, C: sectionC, D: sectionD, E: sectionE };
+  track('bovenbouw_output_generated');
+  return output;
+}

--- a/Leerdoelengenerator-main/src/features/kerndoelen/KerndoelSelector.tsx
+++ b/Leerdoelengenerator-main/src/features/kerndoelen/KerndoelSelector.tsx
@@ -1,15 +1,51 @@
 import React from 'react';
-import type { Kerndoel } from '../../lib/standards/types';
+import type { Kerndoel, Leergebied, Sector } from '../../lib/standards/types';
+import { track } from '../../services/telemetry';
 
 interface Props {
+  sector: Sector;
+  voSublevel?: 'onderbouw' | 'bovenbouw';
   kerndoelen: Kerndoel[];
   selected: string[];
   toggle: (id: string) => void;
+  leergebied?: Leergebied;
+  setLeergebied?: (lg: Leergebied) => void;
 }
 
-export function KerndoelSelector({ kerndoelen, selected, toggle }: Props) {
+export function KerndoelSelector({
+  sector,
+  voSublevel,
+  kerndoelen,
+  selected,
+  toggle,
+  leergebied,
+  setLeergebied,
+}: Props) {
+  const isFunderend = ['PO', 'SO', 'VO', 'VSO'].includes(sector);
+  const showLeergebieden =
+    isFunderend && (sector !== 'VO' || voSublevel === 'onderbouw');
+
   return (
     <div className="flex flex-col gap-2">
+      {showLeergebieden && setLeergebied && (
+        <div className="mb-2 flex gap-4">
+          {(['BURGERSCHAP', 'DG'] as Leergebied[]).map((lg) => (
+            <label key={lg} className="inline-flex items-center gap-1">
+              <input
+                type="radio"
+                name="leergebied"
+                value={lg}
+                checked={leergebied === lg}
+                onChange={() => {
+                  track('leergebied_selected', { leergebied: lg });
+                  setLeergebied(lg);
+                }}
+              />
+              <span>{lg}</span>
+            </label>
+          ))}
+        </div>
+      )}
       {kerndoelen.map((kd) => (
         <label key={kd.id} className="inline-flex items-center gap-2">
           <input

--- a/Leerdoelengenerator-main/src/features/kerndoelen/mappings/slo-funderend.ts
+++ b/Leerdoelengenerator-main/src/features/kerndoelen/mappings/slo-funderend.ts
@@ -1,15 +1,54 @@
-import type { Kerndoel } from '../../../lib/standards/types';
+import type { AiBaanSettings, Kerndoel } from '../../../lib/standards/types';
+import { applyAiBaanRules } from '../../ai-banen/applyAiBaanRules';
+import { track } from '../../../services/telemetry';
 
-export interface FunderendOutput {
-  kerndoel: Kerndoel;
-  didactischeDoelen: string[];
-  werkvormen: string[];
+export interface Section {
+  title: string;
+  content: string[];
 }
 
-export function mapKerndoel(kerndoel: Kerndoel): FunderendOutput {
-  return {
-    kerndoel,
-    didactischeDoelen: [],
-    werkvormen: [],
+export interface FunderendOutput {
+  A: Section; // Officiële kerndoelen
+  B: Section; // Didactische leerdoelen
+  C: Section; // Werkvormen
+  D: Section; // Differentiatie & TOS
+  E: Section; // Bewijsvormen
+}
+
+export function mapKerndoel(
+  kerndoel: Kerndoel,
+  settings: AiBaanSettings
+): FunderendOutput {
+  const sectionA: Section = {
+    title: 'Officiële kerndoelen',
+    content: [
+      kerndoel.kernzin,
+      ...kerndoel.subdoelen.map((s) => `${s.code}: ${s.tekst}`),
+    ],
   };
+
+  const sectionB: Section = {
+    title: 'Didactische leerdoelen',
+    content: [],
+  };
+
+  let sectionC: Section = {
+    title: 'Werkvormen',
+    content: [],
+  };
+  sectionC = applyAiBaanRules(sectionC, settings);
+
+  const sectionD: Section = {
+    title: 'Differentiatie & TOS',
+    content: [],
+  };
+
+  const sectionE: Section = {
+    title: 'Bewijsvormen',
+    content: ['Observatie', 'Product + logboek', 'Gesprek'],
+  };
+
+  const output = { A: sectionA, B: sectionB, C: sectionC, D: sectionD, E: sectionE };
+  track('funderend_output_generated');
+  return output;
 }

--- a/Leerdoelengenerator-main/src/features/sector/SectorSelector.tsx
+++ b/Leerdoelengenerator-main/src/features/sector/SectorSelector.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SECTORS, Sector } from '../../constants/sector';
+import { track } from '../../services/telemetry';
 
 interface Props {
   value: Sector;
@@ -10,13 +11,24 @@ export function SectorSelector({ value, onChange }: Props) {
   return (
     <div className="flex flex-col gap-2">
       {SECTORS.map((s) => (
-        <label key={s} className="inline-flex items-center gap-2">
+        <label
+          key={s}
+          className="inline-flex items-center gap-2"
+          title={
+            s === 'VO'
+              ? 'Geldt voor onderbouw bij kerndoelen; bovenbouw werkt met examenprogramma/eindtermen (geen kerndoelen).'
+              : undefined
+          }
+        >
           <input
             type="radio"
             name="sector"
             value={s}
             checked={value === s}
-            onChange={() => onChange(s)}
+            onChange={() => {
+              track('sector_selected', { sector: s });
+              onChange(s);
+            }}
           />
           <span>{s}</span>
         </label>

--- a/Leerdoelengenerator-main/src/features/sector/VoSublevel.tsx
+++ b/Leerdoelengenerator-main/src/features/sector/VoSublevel.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { track } from '../../services/telemetry';
+
+interface Props {
+  value: 'onderbouw' | 'bovenbouw';
+  onChange: (v: 'onderbouw' | 'bovenbouw') => void;
+}
+
+export function VoSublevel({ value, onChange }: Props) {
+  const options: ('onderbouw' | 'bovenbouw')[] = ['onderbouw', 'bovenbouw'];
+  return (
+    <div className="flex flex-col gap-2">
+      {options.map((opt) => (
+        <label key={opt} className="inline-flex items-center gap-2">
+          <input
+            type="radio"
+            name="vo-sublevel"
+            value={opt}
+            checked={value === opt}
+            onChange={() => {
+              track('vo_sublevel_selected', { level: opt });
+              onChange(opt);
+            }}
+          />
+          <span className="capitalize">{opt}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/features/sector/useSector.ts
+++ b/Leerdoelengenerator-main/src/features/sector/useSector.ts
@@ -1,7 +1,12 @@
 import { useState } from 'react';
-import type { Sector } from '../../constants/sector';
+import type { FunderendFlowState, Sector } from '../../lib/standards/types';
 
-export function useSector(initial: Sector = 'MBO') {
-  const [sector, setSector] = useState<Sector>(initial);
-  return { sector, setSector };
+export function useSector(
+  initial: FunderendFlowState = { sector: 'MBO', voSublevel: 'onderbouw' }
+) {
+  const [state, setState] = useState<FunderendFlowState>(initial);
+  const setSector = (sector: Sector) => setState((s) => ({ ...s, sector }));
+  const setVoSublevel = (voSublevel: 'onderbouw' | 'bovenbouw') =>
+    setState((s) => ({ ...s, voSublevel }));
+  return { ...state, setSector, setVoSublevel };
 }

--- a/Leerdoelengenerator-main/src/features/tos/applyTosSupports.ts
+++ b/Leerdoelengenerator-main/src/features/tos/applyTosSupports.ts
@@ -1,7 +1,9 @@
 import type { TosSupport } from '../../lib/standards/types';
+import { track } from '../../services/telemetry';
 
 export function applyTosSupports<T extends { text: string }>(input: T, tos: TosSupport): T {
   let text = input.text;
+  track('tos_option_changed', { hash: JSON.stringify(tos) });
   if (tos.taalvereenvoudiging !== 'uit') {
     // placeholder for simplification logic
     text = text.replace(/\w{10,}/g, (w) => w.slice(0, 10));

--- a/Leerdoelengenerator-main/src/lib/standards/types.ts
+++ b/Leerdoelengenerator-main/src/lib/standards/types.ts
@@ -1,11 +1,16 @@
 export type Sector =
   | 'PO'
   | 'SO'
-  | 'VO_ONDERBOUW'
+  | 'VO'
   | 'VSO'
   | 'MBO'
   | 'HBO'
   | 'WO';
+
+export interface FunderendFlowState {
+  sector: Sector;
+  voSublevel?: 'onderbouw' | 'bovenbouw';
+}
 
 export type Leergebied = 'BURGERSCHAP' | 'DG';
 

--- a/Leerdoelengenerator-main/src/lib/standards/validators/slo.schema.json
+++ b/Leerdoelengenerator-main/src/lib/standards/validators/slo.schema.json
@@ -8,7 +8,9 @@
       "id": { "type": "string" },
       "sectors": {
         "type": "array",
-        "items": { "type": "string" }
+        "items": {
+          "enum": ["PO", "SO", "VO", "VSO", "MBO", "HBO", "WO"]
+        }
       },
       "leergebied": { "type": "string" },
       "kernzin": { "type": "string" },

--- a/Leerdoelengenerator-main/src/services/telemetry.ts
+++ b/Leerdoelengenerator-main/src/services/telemetry.ts
@@ -1,0 +1,4 @@
+export function track(event: string, data?: Record<string, any>) {
+  // Placeholder telemetry implementation
+  console.log('telemetry', event, data);
+}

--- a/Leerdoelengenerator-main/tests/applyAiBaanRules.test.ts
+++ b/Leerdoelengenerator-main/tests/applyAiBaanRules.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { applyAiBaanRules } from '@/features/ai-banen/applyAiBaanRules';
+import type { AiBaanSettings } from '@/lib/standards/types';
+
+describe('applyAiBaanRules', () => {
+  const section = { content: ['Werkvorm 1'] };
+  it('Baan1 ⇒ géén Transp/Proces/Reflectie', () => {
+    const settings: AiBaanSettings = { baan: 1, transparantie: false, procesbewijzen: false };
+    const res = applyAiBaanRules(section, settings);
+    expect(res.content.some((c) => /Transparantie/.test(c))).toBe(false);
+  });
+
+  it('Baan2 ⇒ wel Transp/Proces/Reflectie', () => {
+    const settings: AiBaanSettings = { baan: 2, transparantie: true, procesbewijzen: true };
+    const res = applyAiBaanRules(section, settings);
+    expect(res.content.join(' ')).toMatch(/Transparantie/);
+    expect(res.content.join(' ')).toMatch(/Procesbewijzen/);
+    expect(res.content.join(' ')).toMatch(/Reflectie/);
+  });
+});

--- a/Leerdoelengenerator-main/tests/applyTosSupports.test.ts
+++ b/Leerdoelengenerator-main/tests/applyTosSupports.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { applyTosSupports } from '@/features/tos/applyTosSupports';
+import type { TosSupport } from '@/lib/standards/types';
+
+describe('applyTosSupports', () => {
+  it('officiële bron blijft onaangeroerd', () => {
+    const input = { text: 'Officiële tekst' };
+    const tos: TosSupport = {
+      spraakNaarTekst: false,
+      taalvereenvoudiging: 'uit',
+      visueleHints: false,
+      woordenschatBank: false,
+      leesniveau: 'A1',
+    };
+    const res = applyTosSupports(input, tos);
+    expect(res.text).toBe('Officiële tekst');
+  });
+});

--- a/Leerdoelengenerator-main/tests/integration/funderendAndBovenbouw.test.ts
+++ b/Leerdoelengenerator-main/tests/integration/funderendAndBovenbouw.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { loadKerndoelen } from '@/lib/standards';
+import { mapKerndoel } from '@/features/kerndoelen/mappings/slo-funderend';
+import { generateFromEindtermen } from '@/features/examenprogramma/generateFromEindtermen';
+import type { AiBaanSettings } from '@/lib/standards/types';
+
+const settings: AiBaanSettings = { baan: 2, transparantie: true, procesbewijzen: true };
+
+describe('Integration flows', () => {
+  it('Case A: VO onderbouw DG baan2', () => {
+    const data = loadKerndoelen('dg_funderend.v1.json');
+    const kd = data[0];
+    const res = mapKerndoel(kd, settings);
+    expect(res.A.content[0]).toBe(kd.kernzin);
+    expect(res.C.content.join(' ')).toMatch(/Transparantie/);
+  });
+
+  it('Case B: VO bovenbouw eindterm baan2', () => {
+    const res = generateFromEindtermen(
+      {
+        vak: 'Nederlands',
+        niveau: 'havo',
+        eindtermen: 'De kandidaat kan argumenten analyseren.'
+      },
+      settings
+    );
+    expect(res.A.content[0]).toBe('De kandidaat kan argumenten analyseren.');
+    expect(res.C.content.join(' ')).toMatch(/Transparantie/);
+    expect(res.E.content.join(' ')).toMatch(/autonomie/);
+  });
+});

--- a/Leerdoelengenerator-main/tests/smoke.test.ts
+++ b/Leerdoelengenerator-main/tests/smoke.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { loadKerndoelen } from '@/lib/standards';
+import { mapKerndoel } from '@/features/kerndoelen/mappings/slo-funderend';
+import { generateFromEindtermen } from '@/features/examenprogramma/generateFromEindtermen';
+import type { AiBaanSettings } from '@/lib/standards/types';
+
+describe('Smoke flows', () => {
+  const settings: AiBaanSettings = { baan: 2, transparantie: true, procesbewijzen: true };
+
+  it('VSO > Burgerschap > Baan 2 > export OK', () => {
+    const data = loadKerndoelen('bg_funderend.v1.json');
+    const kd = data.find((k) => k.sectors.includes('VSO'))!;
+    const res = mapKerndoel(kd, settings);
+    expect(res.C.content.join(' ')).toMatch(/Transparantie/);
+  });
+
+  it('VO > bovenbouw > eindtermen plakken > Baan 2 > export OK', () => {
+    const res = generateFromEindtermen(
+      { vak: 'Nederlands', niveau: 'havo', eindtermen: 'Schrijfvaardigheid' },
+      settings
+    );
+    expect(res.C.content.join(' ')).toMatch(/Transparantie/);
+  });
+});


### PR DESCRIPTION
## Summary
- extend sector types with VO + sublevel tracking and feature flag
- support funderend kerndoelen and VO bovenbouw eindtermen flows with telemetry
- validate datasets across PO/SO/VO/VSO and update schema/tests

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c41a3bec008330a9d09ac4d033978e