### PR TITLE
feat(examples): add voorbeeldcases for PO, SO, VO(onderbouw), VSO and WO + sector filter

### DIFF
--- a/Leerdoelengenerator-main/src/data/examples/voorbeeldcases.funderend+wo.v1.json
+++ b/Leerdoelengenerator-main/src/data/examples/voorbeeldcases.funderend+wo.v1.json
@@ -1,0 +1,163 @@
+[
+  {
+    "id": "po-dg-mediawijsheid",
+    "titel": "PO – DG: Mediawijs nieuwsbericht",
+    "sector": "PO",
+    "leergebied": "DG",
+    "korteBeschrijving": "Leerlingen vergelijken twee kinderberichten en checken bron, bedoeling en betrouwbaarheid.",
+    "baan": 2,
+    "inputs": [
+      "Sector=PO, Leergebied=Digitale geletterdheid",
+      "Kerndoel: media & informatievaardigheid (selecteer 1 kaart)",
+      "TOS: taalvereenvoudiging=licht"
+    ],
+    "expected": [
+      "Officiële kerndoeltekst (readonly)",
+      "Didactische leerdoelen in kindtaal",
+      "Werkvorm Baan 1 (zonder AI) + Baan 2 (met AI en transparantie)",
+      "Reflectievragen over juistheid en bias"
+    ]
+  },
+  {
+    "id": "po-burg-klassafspraken",
+    "titel": "PO – Burgerschap: Klasafspraken & dialoog",
+    "sector": "PO",
+    "leergebied": "BURGERSCHAP",
+    "korteBeschrijving": "Klas maakt gezamenlijke afspraken na een kringgesprek over ‘samen spelen, samen delen’.",
+    "baan": 1,
+    "inputs": [
+      "Sector=PO, Leergebied=Burgerschap",
+      "Kerndoel: democratische cultuur of sociale/ morele ontwikkeling",
+      "Output: observatiepunten + product (poster/afsprakenkaart)"
+    ],
+    "expected": [
+      "Officiële kerndoeltekst",
+      "Werkvorm zonder AI, met differentiatie",
+      "Bewijsvorm: observatie + klasposter"
+    ]
+  },
+  {
+    "id": "so-dg-spraak-naar-tekst",
+    "titel": "SO – DG: Spreek je verhaal (spraak-naar-tekst)",
+    "sector": "SO",
+    "leergebied": "DG",
+    "korteBeschrijving": "Leerlingen met TOS dicteren een kort ervaringsverhaal en redigeren dit samen.",
+    "baan": 2,
+    "inputs": [
+      "Sector=SO, Leergebied=DG",
+      "TOS: spraakNaarTekst=true, taalvereenvoudiging=sterk, visueleHints=true",
+      "Kerndoel: communiceren met digitale middelen"
+    ],
+    "expected": [
+      "Officiële kerndoeltekst",
+      "Baan-2: transparantie + logboek (versies van de tekst)",
+      "TOS-tips en pictogram-stappenplan"
+    ]
+  },
+  {
+    "id": "so-burg-rollen-en-regels",
+    "titel": "SO – Burgerschap: Rollen, regels en veiligheid",
+    "sector": "SO",
+    "leergebied": "BURGERSCHAP",
+    "korteBeschrijving": "Rollenspel: ‘Wat doe je als…?’ rondom regels op het schoolplein en online gedrag.",
+    "baan": 1,
+    "inputs": [
+      "Sector=SO, Leergebied=Burgerschap",
+      "Kerndoel: veilige schoolomgeving/ sociale omgang"
+    ],
+    "expected": [
+      "Officiële kerndoeltekst",
+      "Werkvorm zonder AI met duidelijke stappen",
+      "Bewijsvorm: observatie + korte nabespreking"
+    ]
+  },
+  {
+    "id": "vo-dg-factcheck",
+    "titel": "VO (onderbouw) – DG: Fact-check challenge",
+    "sector": "VO",
+    "leergebied": "DG",
+    "korteBeschrijving": "Leerlingen onderzoeken een viraal bericht: is het waar? Methodisch en transparant werken.",
+    "baan": 2,
+    "inputs": [
+      "Sector=VO (onderbouw), Leergebied=DG",
+      "Kerndoel: informatievaardigheid/ veiligheid & betrouwbaarheid",
+      "Baan=2, Reflectie verplicht"
+    ],
+    "expected": [
+      "Officiële kerndoeltekst (readonly)",
+      "Werkvorm met AI-ondersteuning + bronvermelding prompts",
+      "Processtukken: logboek + reflectie"
+    ]
+  },
+  {
+    "id": "vo-burg-debat",
+    "titel": "VO (onderbouw) – Burgerschap: Mini-debat lokaal onderwerp",
+    "sector": "VO",
+    "leergebied": "BURGERSCHAP",
+    "korteBeschrijving": "Teams bereiden een debat voor over een actuele schoolkwestie; argumentatie & respect.",
+    "baan": 1,
+    "inputs": [
+      "Sector=VO (onderbouw), Leergebied=Burgerschap",
+      "Kerndoel: democratische besluitvorming/ dialoog"
+    ],
+    "expected": [
+      "Officiële kerndoeltekst",
+      "Werkvorm zonder AI + rubriek-haakjes",
+      "Formatieve peer-feedback"
+    ]
+  },
+  {
+    "id": "vso-dg-veilig-online",
+    "titel": "VSO – DG: Veilig online & wachtwoorden",
+    "sector": "VSO",
+    "leergebied": "DG",
+    "korteBeschrijving": "Praktijkopdracht: sterk wachtwoord maken, 2FA instellen en phishing herkennen.",
+    "baan": 2,
+    "inputs": [
+      "Sector=VSO, Leergebied=DG",
+      "TOS: visueleHints=true",
+      "Kerndoel: veilig en verantwoord digitaal handelen"
+    ],
+    "expected": [
+      "Officiële kerndoeltekst",
+      "Checklist handelingen + bewijs (screenshot/mentorcheck)",
+      "Baan-2 transparantie & korte reflectie"
+    ]
+  },
+  {
+    "id": "vso-burg-mededeling",
+    "titel": "VSO – Burgerschap: Ik & de buurt (mededeling oefenen)",
+    "sector": "VSO",
+    "leergebied": "BURGERSCHAP",
+    "korteBeschrijving": "Leerlingen maken een korte mededeling voor een buurthuis-activiteit.",
+    "baan": 1,
+    "inputs": [
+      "Sector=VSO, Leergebied=Burgerschap",
+      "Doel: oefenen sociale participatie",
+      "Product: 30-sec pitch + kaartje/flyer"
+    ],
+    "expected": [
+      "Officiële kerndoeltekst",
+      "Observatielijst sociaal-communicatieve vaardigheden",
+      "Eenvoudige rubric (3 niveaus)"
+    ]
+  },
+  {
+    "id": "wo-ai-ethiek-essay",
+    "titel": "WO – AI-ethiek: Position paper met bronkritiek",
+    "sector": "WO",
+    "leergebied": "ALGEMEEN",
+    "korteBeschrijving": "Student schrijft een kort betoog over AI-toepassing in onderwijs met transparante AI-inzet.",
+    "baan": 2,
+    "inputs": [
+      "Sector=WO",
+      "Kader: eigen leeruitkomst + ethiek/kritisch denken",
+      "Product: 1200-woorden essay + promptlog"
+    ],
+    "expected": [
+      "Didactische leeruitkomsten (geen kerndoelen)",
+      "Baan-2: transparantie, logboek en reflectie",
+      "Beoordeling: argumentatie + bronnen + proces"
+    ]
+  }
+]

--- a/Leerdoelengenerator-main/src/data/examples/voorbeeldcases.hbo.v1.json
+++ b/Leerdoelengenerator-main/src/data/examples/voorbeeldcases.hbo.v1.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "hbo-ict-code-review",
+    "titel": "HBO ICT – AI code review",
+    "sector": "HBO",
+    "leergebied": "DG",
+    "korteBeschrijving": "Studenten gebruiken AI om code te reviewen en verbeteren.",
+    "baan": 2,
+    "inputs": [
+      "Sector=HBO, Profiel=ICT",
+      "Onderwerp: code kwaliteit",
+      "Baan=2"
+    ],
+    "expected": [
+      "AI review suggesties",
+      "Transparantie logboek",
+      "Reflectie op verbeteringen"
+    ]
+  }
+]

--- a/Leerdoelengenerator-main/src/data/examples/voorbeeldcases.mbo.v1.json
+++ b/Leerdoelengenerator-main/src/data/examples/voorbeeldcases.mbo.v1.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "mbo-zorg-digitaal-dossier",
+    "titel": "MBO Zorg – Veilig digitaal dossier",
+    "sector": "MBO",
+    "leergebied": "DG",
+    "korteBeschrijving": "Studenten oefenen met veilig bijhouden van patiëntinformatie.",
+    "baan": 2,
+    "inputs": [
+      "Sector=MBO, Profiel=Zorg",
+      "Onderwerp: privacy en gegevensbescherming"
+    ],
+    "expected": [
+      "Leerdoel over AVG",
+      "Werkvorm met AI",
+      "Reflectie op privacy"
+    ]
+  },
+  {
+    "id": "mbo-sport-trainingsplan",
+    "titel": "MBO Sport – Trainingsplan analyseren",
+    "sector": "MBO",
+    "leergebied": "ALGEMEEN",
+    "korteBeschrijving": "Studenten maken en bespreken een trainingsplan.",
+    "baan": 1,
+    "inputs": [
+      "Sector=MBO, Profiel=Sport",
+      "Onderwerp: planning en evaluatie"
+    ],
+    "expected": [
+      "Leerdoel over analyseren",
+      "Werkvorm zonder AI"
+    ]
+  }
+]

--- a/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
+++ b/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { getCasesBySector } from '@/lib/examples';
+import { useSector } from '@/features/sector/useSector';
+
+export function Voorbeeldcases() {
+  const { sector } = useSector();
+  const cases = getCasesBySector(sector);
+
+  if (cases.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {cases.map((c) => (
+        <div key={c.id} className="rounded border p-2">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold">{c.titel}</h3>
+            <span className="rounded bg-gray-200 px-2 text-xs">Baan {c.baan}</span>
+          </div>
+          <p className="text-sm text-gray-600">{c.korteBeschrijving}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/lib/examples/index.ts
+++ b/Leerdoelengenerator-main/src/lib/examples/index.ts
@@ -1,0 +1,21 @@
+import type { Sector } from '@/lib/standards/types';
+import base from '@/data/examples/voorbeeldcases.funderend+wo.v1.json';
+import mbo from '@/data/examples/voorbeeldcases.mbo.v1.json';
+import hbo from '@/data/examples/voorbeeldcases.hbo.v1.json';
+
+export interface VoorbeeldCase {
+  id: string; // slug, uniek
+  titel: string;
+  sector: Sector;
+  leergebied?: 'BURGERSCHAP' | 'DG' | 'ALGEMEEN';
+  korteBeschrijving: string;
+  baan: 1 | 2;
+  inputs: string[];
+  expected: string[];
+}
+
+export const allVoorbeeldcases: VoorbeeldCase[] = [...mbo, ...hbo, ...base];
+
+export function getCasesBySector(sector: Sector) {
+  return allVoorbeeldcases.filter((c) => c.sector === sector);
+}


### PR DESCRIPTION
## Summary
- add voorbeeldcases dataset for funderend education and WO
- merge example datasets and provide sector filter
- display voorbeelden per sector with baan badge

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c41c680cec83308cee2a3c3d42edc8