### PR TITLE
feat(ui): add SectorSelector and force funderend split on

### DIFF
--- a/Leerdoelengenerator-main/src/config.ts
+++ b/Leerdoelengenerator-main/src/config.ts
@@ -1,5 +1,7 @@
+import { FEATURE_SLO_KERNDOELEN_FUNDEREND } from '@/lib/config/flags';
+
 export const feature = {
   aiReadyGoalsV2: import.meta.env.VITE_FEATURE_AI_READY_GOALS_V2 === "true",
-  sloFunderend: import.meta.env.VITE_FEATURE_SLO_KERNDOELEN_FUNDEREND === 'true',
+  sloFunderend: FEATURE_SLO_KERNDOELEN_FUNDEREND,
 };
 

--- a/Leerdoelengenerator-main/src/constants/education.ts
+++ b/Leerdoelengenerator-main/src/constants/education.ts
@@ -1,13 +1,15 @@
 export const EDUCATION_TYPES = [
+  "PO",
+  "SO",
+  "VO",
+  "VSO",
   "MBO",
   "HBO",
   "WO",
-  "VO",
-  "VSO",
 ] as const;
 export type Education = typeof EDUCATION_TYPES[number];
 
-export const LEVEL_OPTIONS: Record<Exclude<Education, "VO">, string[]> = {
+export const LEVEL_OPTIONS: Partial<Record<Education, string[]>> = {
   MBO: ["Niveau 1", "Niveau 2", "Niveau 3", "Niveau 4"],
   HBO: ["Bachelor", "Associate Degree", "Master"],
   WO: ["Bachelor", "Master"],

--- a/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
+++ b/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import { getCasesBySector } from '@/lib/examples';
+import { allVoorbeeldcases } from '@/lib/examples';
 import { useSector } from '@/features/sector/useSector';
 
 export function Voorbeeldcases() {
   const { sector } = useSector();
-  const cases = getCasesBySector(sector);
+  const visibleCases = allVoorbeeldcases.filter(
+    (c) => !sector || c.sector === sector
+  );
 
-  if (cases.length === 0) {
+  if (visibleCases.length === 0) {
     return null;
   }
 
   return (
     <div className="flex flex-col gap-2">
-      {cases.map((c) => (
+      {visibleCases.map((c) => (
         <div key={c.id} className="rounded border p-2">
           <div className="flex items-center justify-between">
             <h3 className="font-semibold">{c.titel}</h3>

--- a/Leerdoelengenerator-main/src/features/sector/SectorSelector.tsx
+++ b/Leerdoelengenerator-main/src/features/sector/SectorSelector.tsx
@@ -1,38 +1,38 @@
 import React from 'react';
-import { SECTORS, Sector } from '../../constants/sector';
-import { track } from '../../services/telemetry';
+import type { Sector } from '@/lib/standards/types';
 
-interface Props {
-  value: Sector;
-  onChange: (sector: Sector) => void;
-}
+type Props = {
+  value: string | null;
+  onChange: (v: Sector) => void;
+};
 
-export function SectorSelector({ value, onChange }: Props) {
+export default function SectorSelector({ value, onChange }: Props) {
+  const options = [
+    { value: 'PO', label: 'PO' },
+    { value: 'SO', label: 'SO' },
+    { value: 'VO', label: 'VO' },
+    { value: 'VSO', label: 'VSO' },
+    { value: 'MBO', label: 'MBO' },
+    { value: 'HBO', label: 'HBO' },
+    { value: 'WO', label: 'WO' },
+  ];
   return (
-    <div className="flex flex-col gap-2">
-      {SECTORS.map((s) => (
-        <label
-          key={s}
-          className="inline-flex items-center gap-2"
-          title={
-            s === 'VO'
-              ? 'Geldt voor onderbouw bij kerndoelen; bovenbouw werkt met examenprogramma/eindtermen (geen kerndoelen).'
-              : undefined
-          }
-        >
-          <input
-            type="radio"
-            name="sector"
-            value={s}
-            checked={value === s}
-            onChange={() => {
-              track('sector_selected', { sector: s });
-              onChange(s);
-            }}
-          />
-          <span>{s}</span>
-        </label>
-      ))}
+    <div className="space-y-2">
+      <label className="font-medium">Onderwijssector *</label>
+      <div className="grid grid-cols-2 gap-2">
+        {options.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => onChange(o.value as Sector)}
+            className={`rounded-lg border p-2 text-left ${
+              value === o.value ? 'bg-emerald-50 border-emerald-500' : 'bg-white'
+            }`}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/Leerdoelengenerator-main/src/features/sector/useSector.ts
+++ b/Leerdoelengenerator-main/src/features/sector/useSector.ts
@@ -1,10 +1,8 @@
 import { useState } from 'react';
-import type { FunderendFlowState, Sector } from '../../lib/standards/types';
+import type { FlowState, Sector } from '../../lib/standards/types';
 
-export function useSector(
-  initial: FunderendFlowState = { sector: 'MBO', voSublevel: 'onderbouw' }
-) {
-  const [state, setState] = useState<FunderendFlowState>(initial);
+export function useSector(initial: FlowState = { sector: null }) {
+  const [state, setState] = useState<FlowState>(initial);
   const setSector = (sector: Sector) => setState((s) => ({ ...s, sector }));
   const setVoSublevel = (voSublevel: 'onderbouw' | 'bovenbouw') =>
     setState((s) => ({ ...s, voSublevel }));

--- a/Leerdoelengenerator-main/src/features/sector/utils.ts
+++ b/Leerdoelengenerator-main/src/features/sector/utils.ts
@@ -1,0 +1,5 @@
+import type { Sector } from '@/lib/standards/types';
+
+export function isFunderend(sector: Sector | null): boolean {
+  return ['PO', 'SO', 'VO', 'VSO'].includes(sector ?? '');
+}

--- a/Leerdoelengenerator-main/src/lib/config/flags.ts
+++ b/Leerdoelengenerator-main/src/lib/config/flags.ts
@@ -1,0 +1,2 @@
+// src/lib/config/flags.ts
+export const FEATURE_SLO_KERNDOELEN_FUNDEREND = true; // force ON

--- a/Leerdoelengenerator-main/src/lib/standards/types.ts
+++ b/Leerdoelengenerator-main/src/lib/standards/types.ts
@@ -7,8 +7,8 @@ export type Sector =
   | 'HBO'
   | 'WO';
 
-export interface FunderendFlowState {
-  sector: Sector;
+export interface FlowState {
+  sector: Sector | null;
   voSublevel?: 'onderbouw' | 'bovenbouw';
 }
 

--- a/Leerdoelengenerator-main/tests/integration/sectorFlow.test.tsx
+++ b/Leerdoelengenerator-main/tests/integration/sectorFlow.test.tsx
@@ -1,0 +1,36 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from '@/App';
+
+function renderApp() {
+  const div = document.createElement('div');
+  document.body.appendChild(div);
+  const root = createRoot(div);
+  root.render(<App />);
+  return { div, root };
+}
+
+describe('sector flow', () => {
+  it('hides fields until sector chosen and handles funderend', () => {
+    const { div, root } = renderApp();
+    expect(div.querySelector('input[name="lane"]')).toBeNull();
+    const poBtn = Array.from(div.querySelectorAll('button')).find(b => b.textContent === 'PO') as HTMLButtonElement;
+    poBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(div.querySelector('input[name="lane"]')).not.toBeNull();
+    const niveauLabel = Array.from(div.querySelectorAll('label')).find(l => l.textContent?.includes('Niveau *'));
+    expect(niveauLabel).toBeUndefined();
+    root.unmount();
+  });
+
+  it('shows niveau for HBO', () => {
+    const { div, root } = renderApp();
+    const hboBtn = Array.from(div.querySelectorAll('button')).find(b => b.textContent === 'HBO') as HTMLButtonElement;
+    hboBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(div.querySelector('input[name="lane"]')).not.toBeNull();
+    const niveauLabel = Array.from(div.querySelectorAll('label')).find(l => l.textContent?.includes('Niveau *'));
+    expect(niveauLabel).toBeDefined();
+    root.unmount();
+  });
+});

--- a/Leerdoelengenerator-main/tests/isFunderend.test.ts
+++ b/Leerdoelengenerator-main/tests/isFunderend.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { isFunderend } from '@/features/sector/utils';
+
+describe('isFunderend', () => {
+  it('returns true for funderend sectors', () => {
+    ['PO', 'SO', 'VO', 'VSO'].forEach((s) => {
+      expect(isFunderend(s)).toBe(true);
+    });
+  });
+  it('returns false for other sectors', () => {
+    ['MBO', 'HBO', 'WO'].forEach((s) => {
+      expect(isFunderend(s)).toBe(false);
+    });
+  });
+});

--- a/Leerdoelengenerator-main/tests/sectorSelector.test.tsx
+++ b/Leerdoelengenerator-main/tests/sectorSelector.test.tsx
@@ -1,0 +1,20 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import SectorSelector from '@/features/sector/SectorSelector';
+
+describe('SectorSelector', () => {
+  it('renders 7 options and handles click', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const onChange = vi.fn();
+    const root = createRoot(div);
+    root.render(<SectorSelector value={null} onChange={onChange} />);
+    const buttons = div.querySelectorAll('button');
+    expect(buttons.length).toBe(7);
+    buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onChange).toHaveBeenCalledWith('PO');
+    root.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- force FEATURE_SLO_KERNDOELEN_FUNDEREND to true
- add SectorSelector and isFunderend utilities
- gate wizard fields by selected sector and hide niveau for funderend
- expand education constants and filter voorbeeldcases by sector
- add unit and integration tests for sector flow

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/glob)*

------
https://chatgpt.com/codex/tasks/task_e_68c41e27e43c83309ed95a6c4e8a63fe