### PR TITLE
feat(domain-split): hard split Funderend vs MBO/HBO/WO with per-domain sources and mandatory “Basis:” section

### DIFF
--- a/Leerdoelengenerator-main/src/components/LevelPicker.tsx
+++ b/Leerdoelengenerator-main/src/components/LevelPicker.tsx
@@ -1,36 +1,62 @@
 import { useState } from 'react';
-import { LEVEL_TO_GROUP, type EducationLevel } from '@/types/education';
+import type { EducationLevel } from '@/types/education';
+import { getSourcesForLevel } from '@/config/sources';
 
 export function LevelPicker({ onGenerate }: { onGenerate?: (level: EducationLevel) => void }) {
   const [level, setLevel] = useState<EducationLevel | null>(null);
-  const group = level ? LEVEL_TO_GROUP[level] : null;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (level && onGenerate) onGenerate(level);
   };
 
+  const renderButton = (lvl: EducationLevel, label: string) => (
+    <button
+      type="button"
+      key={lvl}
+      onClick={() => setLevel(lvl)}
+      className={`btn ${level === lvl ? 'btn-primary' : 'btn-outline'}`}
+    >
+      {label}
+    </button>
+  );
+
+  const sources = level ? getSourcesForLevel(level) : [];
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-2">
-      <label htmlFor="level" className="block text-sm font-medium">Niveau</label>
-      <select
-        id="level"
-        required
-        value={level ?? ''}
-        onChange={(e) => setLevel(e.target.value as EducationLevel)}
-        className="select select-bordered w-full"
-      >
-        <option value="" disabled>
-          Kies niveau
-        </option>
-        <option value="PO">PO</option>
-        <option value="SO">SO</option>
-        <option value="VSO">VSO</option>
-        <option value="MBO">MBO</option>
-        <option value="HBO">HBO</option>
-        <option value="WO">WO</option>
-      </select>
-      {group && <p className="text-sm text-muted-foreground">Domeingroep: {group}</p>}
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Funderend onderwijs (SO/PO/V(S)O)</h3>
+        <div className="flex flex-wrap gap-2">
+          {renderButton('PO', 'PO')}
+          {renderButton('SO', 'SO')}
+          {renderButton('VSO', 'V(S)O')}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">MBO/HBO/WO</h3>
+        <div className="flex flex-wrap gap-2">
+          {renderButton('MBO', 'MBO')}
+          {renderButton('HBO', 'HBO')}
+          {renderButton('WO', 'WO')}
+        </div>
+      </div>
+
+      {level && (
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h4 className="text-sm font-medium">Basisbronnen</h4>
+            <span className="badge">Basis wordt vermeld in output</span>
+          </div>
+          <ul className="list-disc list-inside text-sm">
+            {sources.map((s) => (
+              <li key={s.id}>{s.title}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <button type="submit" disabled={!level} className="btn btn-primary w-full">
         Genereer
       </button>

--- a/Leerdoelengenerator-main/src/components/OutputView.tsx
+++ b/Leerdoelengenerator-main/src/components/OutputView.tsx
@@ -1,0 +1,35 @@
+import type React from 'react';
+
+export function OutputView({ text, onRetry }: { text: string; onRetry?: () => void }) {
+  const hasBasis = /(?:\n|^)Basis:\n- /.test(text);
+
+  if (!hasBasis) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-warning">Basisbronnen ontbreken in de output.</p>
+        {onRetry && (
+          <button type="button" className="btn btn-warning" onClick={onRetry}>
+            Opnieuw genereren
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  const [content, basisBlock] = text.split(/\nBasis:\n/);
+  const basisLines = basisBlock.split(/\n/).filter((l) => l.startsWith('- '));
+
+  return (
+    <div className="space-y-4">
+      <pre className="whitespace-pre-wrap">{content}</pre>
+      <div>
+        <h4 className="font-medium">Basis:</h4>
+        <ul className="list-disc list-inside">
+          {basisLines.map((line, idx) => (
+            <li key={idx}>{line.replace(/^-\s*/, '')}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/config/sources.ts
+++ b/Leerdoelengenerator-main/src/config/sources.ts
@@ -1,0 +1,35 @@
+import { EducationLevel, DomainGroup, LEVEL_TO_GROUP } from '@/types/education';
+
+export type SourceDoc = { id: string; title: string; path: string };
+export type SourceSet = { group: DomainGroup; levels?: EducationLevel[]; docs: SourceDoc[] };
+
+export const SOURCES: SourceSet[] = [
+  {
+    group: 'Funderend',
+    docs: [
+      { id: 'kerndoelen-po-so', title: 'Kerndoelen PO/SO', path: '/docs/kerndoelen-po-so.pdf' },
+      { id: 'kerndoelen-burgerschap-digitaal', title: 'Conceptkerndoelen Burgerschap & Digitale geletterdheid', path: '/docs/kerndoelen-burgerschap-digitaal.pdf' },
+      { id: 'ai-go', title: 'AI-GO: Raamwerk AI-geletterdheid', path: '/docs/ai-go.pdf' },
+      { id: 'referentiekader-2', title: 'Referentiekader 2.0', path: '/docs/referentiekader-2.pdf' },
+    ],
+  },
+  {
+    group: 'MBO_HBO_WO',
+    docs: [
+      { id: 'npuls-visie-toetsing', title: 'Npuls: Visie op Toetsing & Examinering', path: '/docs/npuls-visie-toetsing.pdf' },
+      { id: 'npuls-handreiking-1', title: 'Npuls Handreiking 1', path: '/docs/npuls-handreiking-1.pdf' },
+      { id: 'npuls-handreiking-2', title: 'Npuls Handreiking 2', path: '/docs/npuls-handreiking-2.pdf' },
+      { id: 'npuls-handreiking-3', title: 'Npuls Handreiking 3', path: '/docs/npuls-handreiking-3.pdf' },
+      { id: 'npuls-handreiking-4', title: 'Npuls Handreiking 4', path: '/docs/npuls-handreiking-4.pdf' },
+      { id: 'ai-go', title: 'AI-GO: Raamwerk AI-geletterdheid', path: '/docs/ai-go.pdf' },
+      { id: 'referentiekader-2', title: 'Referentiekader 2.0', path: '/docs/referentiekader-2.pdf' },
+    ],
+  },
+];
+
+export function getSourcesForLevel(level: EducationLevel): SourceDoc[] {
+  const group = LEVEL_TO_GROUP[level];
+  const set = SOURCES.find((s) => s.group === group);
+  if (!set) throw new Error(`No source set for group ${group}`);
+  return set.docs;
+}

--- a/Leerdoelengenerator-main/src/server/generate.ts
+++ b/Leerdoelengenerator-main/src/server/generate.ts
@@ -2,14 +2,16 @@ import { GeneratePayload } from '@/api/schema';
 import { LEVEL_TO_GROUP, type EducationLevel } from '@/types/education';
 import { buildPrompt } from '@/generator/prompt';
 import { llmGenerate } from '@/features/generator/llm';
+import { getSourcesForLevel } from '@/config/sources';
 
 export async function generate(reqBody: unknown) {
   const parsed = GeneratePayload.parse(reqBody);
   const level = parsed.level as EducationLevel;
   const group = LEVEL_TO_GROUP[level];
+  const sources = getSourcesForLevel(level);
 
   // safety net: prompt krijgt level + group ingebakken
-  const prompt = buildPrompt({ ...parsed, level, group });
+  const prompt = buildPrompt({ ...parsed, level, group, sources: sources.map((s) => s.title) });
 
   const result = await llmGenerate(prompt);
 

--- a/Leerdoelengenerator-main/tests/generate.sources.spec.ts
+++ b/Leerdoelengenerator-main/tests/generate.sources.spec.ts
@@ -1,0 +1,13 @@
+import { getSourcesForLevel } from '@/config/sources';
+
+test('PO -> Funderend bronnen', () => {
+  const docs = getSourcesForLevel('PO').map(d => d.id);
+  expect(docs).toContain('kerndoelen-po-so');
+  expect(docs).toContain('ai-go');
+});
+
+test('MBO -> Npuls bronnen aanwezig', () => {
+  const docs = getSourcesForLevel('MBO').map(d => d.id);
+  expect(docs).toContain('npuls-handreiking-1');
+  expect(docs).toContain('npuls-visie-toetsing');
+});


### PR DESCRIPTION
## Summary
- Define domain-specific source sets and helper to fetch level-specific documents
- Pass selected source titles into prompt generation so LLMs receive the right basis
- Revamp LevelPicker to show domain sections and live “Basisbronnen” list, and render outputs with a required “Basis:” block

## Testing
- ⚠️ `npm ci` *(403 Forbidden - GET https://registry.npmjs.org/glob)*
- ⚠️ `npm test` *(vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c42d9091a08330a12054221fe4e17f