### PR TITLE
fix(ui): remove hardcoded "HBO – Bachelor" header; add dynamic per-level label and NL Bloom; hide Bloom for PO/SO/V(S)O

### DIFF
--- a/Leerdoelengenerator-main/src/components/GoalItemHeader.tsx
+++ b/Leerdoelengenerator-main/src/components/GoalItemHeader.tsx
@@ -1,0 +1,32 @@
+import { LEVEL_DISPLAY, BLOOM_BY_LEVEL, SHOW_BLOOM } from '@/constants/levels';
+import type { EducationLevel } from '@/types/education';
+
+type Props = {
+  level: EducationLevel;           // UIT result.meta.level
+  degree?: 'Associate degree' | 'Bachelor' | 'Master'; // alleen tonen bij HBO/WO indien aanwezig
+  className?: string;
+};
+
+export function GoalItemHeader({ level, degree, className }: Props) {
+  const label = LEVEL_DISPLAY[level];
+  const showBloom = SHOW_BLOOM[level];
+  const blooms = BLOOM_BY_LEVEL[level];
+
+  const degreeSuffix =
+    (level === 'HBO' || level === 'WO') && degree ? ` – ${degree}` : '';
+
+  return (
+    <div className={className ?? 'flex flex-wrap items-center gap-2 text-sm'}>
+      <span className="inline-flex items-center rounded-full bg-neutral-100 px-2 py-1 font-semibold">
+        {label}{degreeSuffix}
+      </span>
+      {showBloom && (
+        <span className="text-neutral-500">
+          Bloom: {blooms.join(' • ')}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default GoalItemHeader;

--- a/Leerdoelengenerator-main/src/components/OutputView.tsx
+++ b/Leerdoelengenerator-main/src/components/OutputView.tsx
@@ -1,6 +1,11 @@
 import type React from 'react';
+import { GoalItemHeader } from './GoalItemHeader';
+import type { EducationLevel } from '@/types/education';
 
-export function OutputView({ text, onRetry }: { text: string; onRetry?: () => void }) {
+type OutputResult = { text: string; meta: { level: EducationLevel } };
+
+export function OutputView({ result, onRetry }: { result: OutputResult; onRetry?: () => void }) {
+  const { text, meta } = result;
   const hasBasis = /(?:\n|^)Basis:\n- /.test(text);
 
   if (!hasBasis) {
@@ -21,6 +26,7 @@ export function OutputView({ text, onRetry }: { text: string; onRetry?: () => vo
 
   return (
     <div className="space-y-4">
+      <GoalItemHeader level={meta.level} />
       <pre className="whitespace-pre-wrap">{content}</pre>
       <div>
         <h4 className="font-medium">Basis:</h4>

--- a/Leerdoelengenerator-main/src/constants/levels.ts
+++ b/Leerdoelengenerator-main/src/constants/levels.ts
@@ -1,0 +1,26 @@
+import type { EducationLevel } from '@/types/education';
+
+export const LEVEL_DISPLAY: Record<EducationLevel, string> = {
+  PO: 'PO',
+  SO: 'SO',
+  VSO: 'V(S)O',
+  MBO: 'MBO',
+  HBO: 'HBO',
+  WO: 'WO',
+};
+
+// NL Bloom per niveau (bewust eenvoudiger voor funderend)
+export const BLOOM_BY_LEVEL: Record<EducationLevel, string[]> = {
+  PO:  ['onthouden', 'begrijpen', 'toepassen'],
+  SO:  ['onthouden', 'begrijpen', 'toepassen'],
+  VSO: ['onthouden', 'begrijpen', 'toepassen'],
+  MBO: ['toepassen', 'analyseren', 'evalueren'],
+  HBO: ['analyseren', 'evalueren', 'creëren'],
+  WO:  ['analyseren', 'evalueren', 'creëren'],
+};
+
+// Bloom tonen? (verborgen bij funderend)
+export const SHOW_BLOOM: Record<EducationLevel, boolean> = {
+  PO: false, SO: false, VSO: false, MBO: true, HBO: true, WO: true,
+};
+

--- a/Leerdoelengenerator-main/src/server/generate.ts
+++ b/Leerdoelengenerator-main/src/server/generate.ts
@@ -24,5 +24,6 @@ export async function generate(reqBody: unknown) {
   if (outLevel !== level) {
     throw new Error(`VALIDATION_ERROR: Niveau mismatch (gekozen ${level}, output ${outLevel})`);
   }
-  return result;
+  const meta = { level };
+  return { ...result, meta };
 }

--- a/Leerdoelengenerator-main/tests/ui.goal-header.spec.ts
+++ b/Leerdoelengenerator-main/tests/ui.goal-header.spec.ts
@@ -1,0 +1,11 @@
+import { LEVEL_DISPLAY, SHOW_BLOOM } from '@/constants/levels';
+
+test('PO toont GEEN HBO en GEEN Bloom-label', () => {
+  expect(LEVEL_DISPLAY['PO']).toBe('PO');
+  expect(SHOW_BLOOM['PO']).toBe(false);
+});
+
+test('HBO toont Bloom in NL', () => {
+  expect(SHOW_BLOOM['HBO']).toBe(true);
+  // verdere render-test indien je testing-library gebruikt
+});


### PR DESCRIPTION
## Summary
- add constants for level display and Bloom labels
- expose level metadata from server generate function
- render dynamic goal headers with optional Bloom info
- add basic tests for level label and Bloom visibility

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c42f2cacf48330be02be130a10945e