### PR TITLE
fix(ui): rename top block header and enforce level order

### DIFF
--- a/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
+++ b/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
@@ -1,5 +1,6 @@
 import { getAllVoorbeeldcases, getSectorCounts /*, getCasesBySector */ } from '@/lib/examples';
 import type { VoorbeeldCase } from '@/lib/examples';
+import { compareByLevel, LevelKey } from '@/utils/levelOrder';
 
 export default function Voorbeeldcases({ currentSector, debug = false, onSelect }:{
   currentSector?: string | null;
@@ -8,16 +9,19 @@ export default function Voorbeeldcases({ currentSector, debug = false, onSelect 
 }) {
   // TIJDELIJK: zet filter uit om zichtbaarheid te verifiëren:
   // const cases = getCasesBySector(currentSector as any);
-  const cases = getAllVoorbeeldcases();
+  const cases = getAllVoorbeeldcases().sort((a, b) => compareByLevel(a.titel, b.titel));
 
   const counts = getSectorCounts();
+  const countsLine = (['WO','HBO','MBO','VO','VSO','PO','SO'] as LevelKey[])
+    .map((lvl) => `${lvl}:${counts[lvl] ?? 0}`)
+    .join(' • ');
 
   return (
     <div className="space-y-2">
       {debug && (
         <div className="text-xs text-gray-600 p-2 border rounded">
-          <div className="font-semibold mb-1">Debug voorbeelden:</div>
-          <div>PO:{counts.PO ?? 0} • SO:{counts.SO ?? 0} • VO:{counts.VO ?? 0} • VSO:{counts.VSO ?? 0} • MBO:{counts.MBO ?? 0} • HBO:{counts.HBO ?? 0} • WO:{counts.WO ?? 0}</div>
+          <div className="font-semibold mb-1">Overkoepelende kaders & visies</div>
+          <div>{countsLine}</div>
         </div>
       )}
       {cases.map((c) => (

--- a/Leerdoelengenerator-main/src/features/generator/components/SectorGrid.tsx
+++ b/Leerdoelengenerator-main/src/features/generator/components/SectorGrid.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { compareByLevel, LevelKey } from "@/utils/levelOrder";
 
 export function SectorGrid({ value, onChange }: {
   value: { PO?:boolean; SO?:boolean; VO?:boolean; VSO?:boolean; MBO?:boolean; HBO?:boolean; WO?:boolean };
@@ -24,7 +25,7 @@ export function SectorGrid({ value, onChange }: {
     <div className="space-y-2">
       {/* render jouw 7 knoppen/velden; hieronder pseudo */}
       <div className="grid grid-cols-2 gap-2">
-        {["PO","SO","VO","VSO","MBO","HBO","WO"].map(k => (
+        {(['PO','SO','VO','VSO','MBO','HBO','WO'] as LevelKey[]).sort(compareByLevel).map(k => (
           <button
             key={k}
             type="button"

--- a/Leerdoelengenerator-main/src/utils/levelOrder.ts
+++ b/Leerdoelengenerator-main/src/utils/levelOrder.ts
@@ -1,0 +1,55 @@
+export type LevelKey = 'WO' | 'HBO' | 'MBO' | 'VO' | 'VSO' | 'PO' | 'SO';
+
+// Vaste rangorde: lager getal = hoger in de lijst
+const ORDER: Record<LevelKey, number> = {
+  WO: 0,
+  HBO: 1,
+  MBO: 2,
+  VO: 3,
+  VSO: 4,
+  PO: 5,
+  SO: 6,
+};
+
+// Probeert een niveau uit een string te halen (bv. "PO – DG: ..." of "mbo-sport" of "hbo-ict")
+export function extractLevel(input: string): LevelKey | null {
+  if (!input) return null;
+  const s = input.toUpperCase();
+
+  // Strikte checks eerst
+  if (/\bWO\b/.test(s)) return 'WO';
+  if (/\bHBO\b/.test(s)) return 'HBO';
+  if (/\bMBO\b/.test(s)) return 'MBO';
+  if (/\bVSO\b/.test(s)) return 'VSO';
+  // Let op: "VO (onderbouw)" moet VO blijven
+  if (/\bVO\b/.test(s)) return 'VO';
+  if (/\bPO\b/.test(s)) return 'PO';
+  if (/\bSO\b/.test(s)) return 'SO';
+
+  // Veelgebruikte prefixes/slugs (zoals "mbo-ict")
+  if (s.startsWith('WO-') || s.startsWith('WO ')) return 'WO';
+  if (s.startsWith('HBO-') || s.startsWith('HBO ')) return 'HBO';
+  if (s.startsWith('MBO-') || s.startsWith('MBO ')) return 'MBO';
+  if (s.startsWith('VSO-') || s.startsWith('VSO ')) return 'VSO';
+  if (s.startsWith('VO-')  || s.startsWith('VO '))  return 'VO';
+  if (s.startsWith('PO-')  || s.startsWith('PO '))  return 'PO';
+  if (s.startsWith('SO-')  || s.startsWith('SO '))  return 'SO';
+
+  return null;
+}
+
+export function levelRank(input: string): number {
+  const lvl = extractLevel(input);
+  if (!lvl) return Number.POSITIVE_INFINITY; // Onbekend altijd onderaan
+  return ORDER[lvl];
+}
+
+// Comparator om lijsten te sorteren
+export function compareByLevel(a: string, b: string): number {
+  const ra = levelRank(a);
+  const rb = levelRank(b);
+  if (ra !== rb) return ra - rb;
+  // secondairy: alfabetisch, zodat items binnen hetzelfde niveau stabiel staan
+  return a.localeCompare(b, 'nl');
+}
+


### PR DESCRIPTION
## Summary
- rename debug examples header to "Overkoepelende kaders & visies" and show level counts in fixed order
- add level order utility and sort examples and sector grid using WO→HBO→MBO→VO→VSO→PO→SO sequence

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c430a5310483309837982adc810e82