### PR TITLE
feat: add niveau badge logic

### DIFF
--- a/Leerdoelengenerator-main/src/components/NiveauBadge.tsx
+++ b/Leerdoelengenerator-main/src/components/NiveauBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { getNiveauBadge, OnderwijsSector } from '../domain/niveau';
+
+type Props = {
+  sector: OnderwijsSector;
+  programSubtype?: string; // bv. "Bachelor", "Master", "Associate degree"
+};
+
+export default function NiveauBadge({ sector, programSubtype }: Props) {
+  const cfg = getNiveauBadge(sector, programSubtype);
+
+  return (
+    <div aria-label="niveau-badge" className="inline-flex items-center gap-2 rounded-xl border px-3 py-1 text-sm" >
+      <strong>{cfg.title}</strong>
+      {cfg.showBloom && cfg.bloom?.length ? (
+        <span className="opacity-70">Bloom: {cfg.bloom.join(' • ')}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/Leerdoelengenerator-main/src/domain/niveau.test.ts
+++ b/Leerdoelengenerator-main/src/domain/niveau.test.ts
@@ -1,0 +1,33 @@
+import { formatBadgeLine, getNiveauBadge } from './niveau';
+
+describe('Niveau-badge', () => {
+  test('PO toont nooit Bloom en nooit HBO-tekst', () => {
+    const cfg = getNiveauBadge('PO');
+    expect(cfg.showBloom).toBe(false);
+    expect(cfg.title).toMatch(/^PO — Kerndoelen/);
+    expect(cfg.title).not.toMatch(/HBO/i);
+  });
+
+  test('VSO toont nooit Bloom en nooit HBO-tekst', () => {
+    const cfg = getNiveauBadge('VSO');
+    expect(cfg.showBloom).toBe(false);
+    expect(cfg.title).toMatch(/^V\(S\)O — Kerndoelen/);
+    expect(cfg.title).not.toMatch(/HBO/i);
+  });
+
+  test('VO (onderbouw) toont geen Bloom', () => {
+    const cfg = getNiveauBadge('VO');
+    expect(cfg.showBloom).toBe(false);
+  });
+
+  test('HBO toont Bloom en subtype indien meegegeven', () => {
+    const line = formatBadgeLine('HBO', 'Bachelor');
+    expect(line).toMatch(/^HBO — Bachelor/);
+    expect(line).toMatch(/Bloom: analyze • evaluate • create$/);
+  });
+
+  test('MBO/WO tonen Bloom standaard', () => {
+    expect(formatBadgeLine('MBO')).toMatch(/Bloom:/);
+    expect(formatBadgeLine('WO')).toMatch(/Bloom:/);
+  });
+});

--- a/Leerdoelengenerator-main/src/domain/niveau.ts
+++ b/Leerdoelengenerator-main/src/domain/niveau.ts
@@ -1,0 +1,60 @@
+export type OnderwijsSector = 'PO' | 'SO' | 'VSO' | 'VO' | 'MBO' | 'HBO' | 'WO';
+
+export type NiveauBadge = {
+  /** Titeltekst in de badge, bv. "PO — Kerndoelen (SLO)" of "HBO — Bachelor" */
+  title: string;
+  /* Zet true om Bloom-niveaus te tonen in de UI */
+  showBloom: boolean;
+  /* Standaard Bloom-niveaus voor hoger/beroepsonderwijs */
+  bloom?: string[];
+};
+
+const BLOOM_HE: string[] = ['analyze', 'evaluate', 'create'];
+
+/**
+ * Retourneert een sector-bewuste badgeconfig.
+ *
+ * Voor PO/SO/VSO/VO: nooit Bloom; titel volgt SLO-kerndoelen.
+ *
+ * Voor MBO/HBO/WO: optioneel subtype (bv. "Bachelor", "Associate degree", "Master") en Bloom tonen.
+ */
+export function getNiveauBadge(
+  sector: OnderwijsSector,
+  programSubtype?: string
+): NiveauBadge {
+  switch (sector) {
+    case 'PO':
+      return { title: 'PO — Kerndoelen (SLO)', showBloom: false };
+    case 'SO':
+      return { title: 'SO — Kerndoelen (SLO)', showBloom: false };
+    case 'VSO':
+      return { title: 'V(S)O — Kerndoelen (SLO)', showBloom: false };
+    case 'VO':
+      // Onderbouw valt onder SLO-kerndoelen; geen Bloom
+      return { title: 'VO — Onderbouw (SLO-kerndoelen)', showBloom: false };
+    case 'MBO':
+    case 'HBO':
+    case 'WO': {
+      const subtype = (programSubtype ?? '').trim();
+      const base = subtype ? `${sector} — ${subtype}` : sector;
+      return { title: base, showBloom: true, bloom: BLOOM_HE };
+    }
+    default: {
+      // Typedef dekt alles, maar voor de zekerheid:
+      const neverSector: never = sector;
+      throw new Error(`Onbekende sector: ${(neverSector as any) ?? 'undefined'}`);
+    }
+  }
+}
+
+/** Convenience: simpele string voor UI, inclusief Bloom als dat mag */
+export function formatBadgeLine(
+  sector: OnderwijsSector,
+  programSubtype?: string
+): string {
+  const cfg = getNiveauBadge(sector, programSubtype);
+  if (cfg.showBloom && cfg.bloom?.length) {
+    return `${cfg.title} Bloom: ${cfg.bloom.join(' • ')}`;
+  }
+  return cfg.title;
+}


### PR DESCRIPTION
## Summary
- add level badge logic and formatting
- provide React component for displaying level badges
- test level badge behavior across educational sectors

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c43290d1988330bb952ee5275d1c50