### PR TITLE
feat: add sector-specific source mapping

### DIFF
--- a/Leerdoelengenerator-main/src/domain/niveau.ts
+++ b/Leerdoelengenerator-main/src/domain/niveau.ts
@@ -1,0 +1,13 @@
+export type OnderwijsSector = 'PO' | 'SO' | 'VSO' | 'VO' | 'MBO' | 'HBO' | 'WO';
+
+export type NiveauBadge = {
+  title: string;
+  showBloom?: boolean;
+  bloom?: string[];
+};
+
+export function getNiveauBadge(sector: OnderwijsSector, programSubtype?: string): NiveauBadge {
+  const title = programSubtype ? `${sector} – ${programSubtype}` : sector;
+  const showBloom = sector === 'MBO' || sector === 'HBO' || sector === 'WO';
+  return { title, showBloom };
+}

--- a/Leerdoelengenerator-main/src/domain/sources.test.ts
+++ b/Leerdoelengenerator-main/src/domain/sources.test.ts
@@ -1,0 +1,19 @@
+import { getSourcesForSector } from './sources';
+
+describe('Bronselectie per sector', () => {
+  test.each(['PO', 'SO', 'VSO', 'VO'] as const)('%s -> SLO-kerndoelen', (sector) => {
+    const docs = getSourcesForSector(sector);
+    expect(docs).toHaveLength(1);
+    expect(docs[0].source).toBe('SLO');
+    expect(docs[0].title).toMatch(/kerndoelen/i);
+  });
+
+  test.each(['MBO', 'HBO', 'WO'] as const)('%s -> Npuls-set', (sector) => {
+    const docs = getSourcesForSector(sector);
+    const titles = docs.map(d => d.title).join(' | ');
+    expect(docs).toHaveLength(3);
+    expect(titles).toMatch(/AI-GO/i);
+    expect(titles).toMatch(/Toetsing .* AI/i);
+    expect(titles).toMatch(/Referentiekader 2.0/i);
+  });
+});

--- a/Leerdoelengenerator-main/src/domain/sources.ts
+++ b/Leerdoelengenerator-main/src/domain/sources.ts
@@ -1,0 +1,67 @@
+import { OnderwijsSector } from './niveau';
+
+export type BaseDoc = {
+  id: string;
+  title: string;
+  source: 'SLO' | 'Npuls';
+  year?: number;
+};
+
+const SLO_BURGER_DIGI: BaseDoc = {
+  id: 'slo_burgerschap_digitaal_2025',
+  title: 'SLO — Definitieve conceptkerndoelen: burgerschap & digitale geletterdheid (2025)',
+  source: 'SLO',
+  year: 2025,
+};
+
+const NPULS_AIGO: BaseDoc = {
+  id: 'npuls_aigo_2025',
+  title: 'Npuls — AI-GO! Raamwerk AI-geletterdheid (2025)',
+  source: 'Npuls',
+  year: 2025,
+};
+
+const NPULS_HANDREIKING_TOETSING: BaseDoc = {
+  id: 'npuls_handreiking_toetsing_ai_2025',
+  title: 'Npuls — Toetsing & examinering in het tijdperk van AI (Handreiking 1, 2025)',
+  source: 'Npuls',
+  year: 2025,
+};
+
+const NPULS_REFERENTIEKADER: BaseDoc = {
+  id: 'npuls_referentiekader_2_0_2025',
+  title: 'Npuls — Referentiekader 2.0: verantwoord gebruik studiedata & AI (2025)',
+  source: 'Npuls',
+  year: 2025,
+};
+
+export function getSourcesForSector(sector: OnderwijsSector): BaseDoc[] {
+  switch (sector) {
+    case 'PO':
+    case 'SO':
+    case 'VSO':
+    case 'VO':
+      return [SLO_BURGER_DIGI];
+    case 'MBO':
+    case 'HBO':
+    case 'WO':
+      return [NPULS_AIGO, NPULS_HANDREIKING_TOETSING, NPULS_REFERENTIEKADER];
+    default: {
+      const neverSector: never = sector;
+      throw new Error(`Onbekende sector: ${(neverSector as any) ?? 'undefined'}`);
+    }
+  }
+}
+
+/** Handig hulpfunctietje om context aan je generator te geven */
+export function buildGenerationContext(input: {
+  sector: OnderwijsSector;
+  programSubtype?: string;
+}) {
+  const { sector, programSubtype } = input;
+  // Lazy import om circulaire deps te vermijden
+  const { getNiveauBadge } = require('./niveau') as typeof import('./niveau');
+  const badge = getNiveauBadge(sector, programSubtype);
+  const sources = getSourcesForSector(sector);
+  return { badge, sources };
+}

--- a/Leerdoelengenerator-main/src/server/generate.ts
+++ b/Leerdoelengenerator-main/src/server/generate.ts
@@ -1,17 +1,18 @@
 import { GeneratePayload } from '@/api/schema';
-import { LEVEL_TO_GROUP, type EducationLevel } from '@/types/education';
+import { LEVEL_TO_GROUP } from '@/types/education';
 import { buildPrompt } from '@/generator/prompt';
 import { llmGenerate } from '@/features/generator/llm';
-import { getSourcesForLevel } from '@/config/sources';
+import { buildGenerationContext } from '@/domain/sources';
+import type { OnderwijsSector } from '@/domain/niveau';
 
 export async function generate(reqBody: unknown) {
   const parsed = GeneratePayload.parse(reqBody);
-  const level = parsed.level as EducationLevel;
-  const group = LEVEL_TO_GROUP[level];
-  const sources = getSourcesForLevel(level);
+  const sector = parsed.level as OnderwijsSector;
+  const group = LEVEL_TO_GROUP[sector];
+  const { sources } = buildGenerationContext({ sector });
 
   // safety net: prompt krijgt level + group ingebakken
-  const prompt = buildPrompt({ ...parsed, level, group, sources: sources.map((s) => s.title) });
+  const prompt = buildPrompt({ ...parsed, level: sector, group, sources: sources.map((s) => s.title) });
 
   const result = await llmGenerate(prompt);
 
@@ -20,9 +21,9 @@ export async function generate(reqBody: unknown) {
   if (!/^Niveau:\s*(PO|SO|VSO|MBO|HBO|WO)\b/m.test(result.text)) {
     throw new Error('VALIDATION_ERROR: Niveau ontbreekt in output');
   }
-  const outLevel = result.text.match(/^Niveau:\s*(PO|SO|VSO|MBO|HBO|WO)\b/m)?.[1];
-  if (outLevel !== level) {
-    throw new Error(`VALIDATION_ERROR: Niveau mismatch (gekozen ${level}, output ${outLevel})`);
-  }
+    const outLevel = result.text.match(/^Niveau:\s*(PO|SO|VSO|MBO|HBO|WO)\b/m)?.[1];
+    if (outLevel !== sector) {
+      throw new Error(`VALIDATION_ERROR: Niveau mismatch (gekozen ${sector}, output ${outLevel})`);
+    }
   return result;
 }


### PR DESCRIPTION
## Summary
- map SLO and Npuls source documents per sector
- expose buildGenerationContext to fetch badge and sources
- integrate new source lookup into generator and add unit tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c434060c0483309d92a828f6cfe531