### PR TITLE
feat(generator): add sector helpers and lane gating

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -25,11 +25,11 @@ import { geminiService } from "./services/gemini";
 import type { Education, VoLevel, VSOCluster } from "./types/context";
 import { LEVEL_OPTIONS, VO_LEVELS, VSO_CLUSTERS } from "./constants/education";
 import SectorSelector from "@/features/sector/SectorSelector";
-import type { Sector } from "@/lib/standards/types";
-import { isFunderend } from "@/features/sector/utils";
+import { Sector, toCategory, isBaanApplicable } from "@/core/education/ui-adapters";
 import { getVoGradeOptions } from "./utils/vo";
 import NiveauBadge from "@/components/NiveauBadge";
-import { OnderwijsSector, isFunderend } from "@/domain/niveau";
+import { OnderwijsSector } from "@/domain/niveau";
+import { isFunderend } from "@/features/sector/utils";
 import { NiveauCheck } from "./components/NiveauCheck";
 import { feature } from "@/config";
 import { LevelKey } from "./domain/levelProfiles";
@@ -657,6 +657,7 @@ function App() {
   const handleSectorChange = (s: Sector) => {
     setSector(s);
     handleInputChange("education", s);
+    setLane((prev) => (isBaanApplicable(s) ? prev : ""));
   };
   const handleKDImported = (kd: KDStructure) => setImportedKD(kd);
 
@@ -1007,10 +1008,17 @@ function App() {
                     <>
                       {/* Two-Lane keuze */}
                       <ObjectiveForm
+                        sector={sector}
                         lane={lane}
                         onLaneChange={setLane}
                         geminiAvailable={geminiService.isAvailable()}
                       />
+
+                      <div className="source-badge" style={{ marginTop: 8, fontSize: 12, opacity: 0.9 }}>
+                        {toCategory(sector) === 'FUNDEREND'
+                          ? 'Bron: SLO-kerndoelen (funderend onderwijs)'
+                          : 'Bron: Npuls-visie & handreikingen (beroepsonderwijs)'}
+                      </div>
 
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">

--- a/Leerdoelengenerator-main/src/ObjectiveForm.tsx
+++ b/Leerdoelengenerator-main/src/ObjectiveForm.tsx
@@ -1,24 +1,28 @@
 import React from "react";
 import InfoBox from "./components/InfoBox";
+import { Sector, isBaanApplicable } from "@/core/education/ui-adapters";
 
 type Lane = "baan1" | "baan2";
 
 interface ObjectiveFormProps {
+  sector: Sector;
   lane: "" | Lane;
   onLaneChange: (lane: Lane) => void;
   geminiAvailable: boolean;
 }
 
-export function ObjectiveForm({ lane, onLaneChange, geminiAvailable }: ObjectiveFormProps) {
+export function ObjectiveForm({ sector, lane, onLaneChange, geminiAvailable }: ObjectiveFormProps) {
+  const baanEnabled = isBaanApplicable(sector);
   return (
-    <div className="bg-slate-50 border border-slate-200 rounded-lg p-4">
-      <div className="text-sm font-medium text-slate-700 mb-2">Kies aanpak *</div>
+    <fieldset className="bg-slate-50 border border-slate-200 rounded-lg p-4" aria-disabled={!baanEnabled}>
+      <legend className="text-sm font-medium text-slate-700 mb-2">Kies aanpak *</legend>
       <div className="flex flex-wrap gap-4">
         <label className="inline-flex items-center gap-2">
           <input
             type="radio"
             name="lane"
             value="baan1"
+            disabled={!baanEnabled}
             checked={lane === "baan1"}
             onChange={() => onLaneChange("baan1")}
             required
@@ -37,9 +41,9 @@ export function ObjectiveForm({ lane, onLaneChange, geminiAvailable }: Objective
             type="radio"
             name="lane"
             value="baan2"
+            disabled={!baanEnabled || !geminiAvailable}
             checked={lane === "baan2"}
             onChange={() => onLaneChange("baan2")}
-            disabled={!geminiAvailable}
             required
           />
           <span>
@@ -52,7 +56,12 @@ export function ObjectiveForm({ lane, onLaneChange, geminiAvailable }: Objective
           </span>
         </label>
       </div>
-    </div>
+      {!baanEnabled && (
+        <p className="hint mt-2 text-sm text-gray-600">
+          Baan-keuze is alleen van toepassing op het <strong>beroepsonderwijs</strong> (MBO/HBO/WO).
+        </p>
+      )}
+    </fieldset>
   );
 }
 

--- a/Leerdoelengenerator-main/src/core/education/ui-adapters.ts
+++ b/Leerdoelengenerator-main/src/core/education/ui-adapters.ts
@@ -1,0 +1,45 @@
+export type Sector = 'PO'|'SO'|'VSO'|'VO'|'MBO'|'HBO'|'WO';
+export type EducationCategory = 'FUNDEREND'|'BEROEPSONDERWIJS';
+export type Lane = 'BAAN_1'|'BAAN_2';
+
+export function toCategory(sector: Sector): EducationCategory {
+  return (sector === 'PO' || sector === 'SO' || sector === 'VSO' || sector === 'VO')
+    ? 'FUNDEREND'
+    : 'BEROEPSONDERWIJS';
+}
+
+export function isBaanApplicable(sector: Sector): boolean {
+  return toCategory(sector) === 'BEROEPSONDERWIJS';
+}
+
+// Generieke item-typen voor je linker “kaders” en rechter “voorbeelden” lijsten.
+// Als jouw items al een eigen type hebben: voeg minimaal 'sector' of 'category' toe.
+export interface HasSectorOrCategory {
+  sector?: Sector;
+  category?: EducationCategory;
+  [k: string]: any;
+}
+
+export function filterBySectorOrCategory<T extends HasSectorOrCategory>(
+  items: T[],
+  sector: Sector
+): T[] {
+  const cat = toCategory(sector);
+  return (items || []).filter(it => {
+    // 1) Hard op sector matchen als aanwezig
+    if (it.sector) {
+      return toCategory(it.sector) === cat;
+    }
+    // 2) Anders op category matchen als aanwezig
+    if (it.category) {
+      return it.category === cat;
+    }
+    // 3) Geen metadata -> toon toch (of kies false om te verbergen)
+    return false;
+  });
+}
+
+// Helper om lane-state veilig te resetten wanneer sector → FUNDEREND switcht
+export function normalizeLaneForSector(sector: Sector, lane?: Lane): Lane|undefined {
+  return isBaanApplicable(sector) ? lane : undefined;
+}

--- a/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
+++ b/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
@@ -1,15 +1,18 @@
+import { useMemo } from 'react';
 import { getAllVoorbeeldcases, getSectorCounts /*, getCasesBySector */ } from '@/lib/examples';
 import type { VoorbeeldCase } from '@/lib/examples';
 import { compareByLevel, LevelKey } from '@/utils/levelOrder';
+import { filterBySectorOrCategory, Sector } from '@/core/education/ui-adapters';
 
 export default function Voorbeeldcases({ currentSector, debug = false, onSelect }:{
   currentSector?: string | null;
   debug?: boolean;
   onSelect?: (c: VoorbeeldCase) => void;
 }) {
-  // TIJDELIJK: zet filter uit om zichtbaarheid te verifiëren:
-  // const cases = getCasesBySector(currentSector as any);
-  const cases = getAllVoorbeeldcases().sort((a, b) => compareByLevel(a.titel, b.titel));
+  const cases = useMemo(() => {
+    const all = getAllVoorbeeldcases().sort((a, b) => compareByLevel(a.titel, b.titel));
+    return currentSector ? filterBySectorOrCategory(all, currentSector as Sector) : all;
+  }, [currentSector]);
 
   const counts = getSectorCounts();
   const countsLine = (['WO','HBO','MBO','VO','VSO','PO','SO'] as LevelKey[])


### PR DESCRIPTION
## Summary
- add UI helpers for sector categorization, lane gating and filtering
- gate lane selection by education sector and show category source badge
- filter example cases by sector or category

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c458c8655883308575228e65c38ad4