### PR TITLE
Update Npuls resource links

### DIFF
--- a/Leerdoelengenerator-main/src/config/sources.ts
+++ b/Leerdoelengenerator-main/src/config/sources.ts
@@ -9,20 +9,44 @@ export const SOURCES: SourceSet[] = [
     docs: [
       { id: 'kerndoelen-po-so', title: 'Kerndoelen PO/SO', path: '/docs/kerndoelen-po-so.pdf' },
       { id: 'kerndoelen-burgerschap-digitaal', title: 'Conceptkerndoelen Burgerschap & Digitale geletterdheid', path: '/docs/kerndoelen-burgerschap-digitaal.pdf' },
-      { id: 'ai-go', title: 'AI-GO: Raamwerk AI-geletterdheid', path: '/docs/ai-go.pdf' },
-      { id: 'referentiekader-2', title: 'Referentiekader 2.0', path: '/docs/referentiekader-2.pdf' },
+      {
+        id: 'ai-go',
+        title: 'AI-GO: Raamwerk AI-geletterdheid',
+        path: 'https://npuls.nl/kennisbank/ai-go-een-raamwerk-voor-ai-geletterdheid-in-het-onderwijs',
+      },
+      {
+        id: 'referentiekader-2',
+        title: 'Referentiekader 2.0',
+        path: 'https://npuls.nl/kennisbank/referentiekader-2-0-verantwoord-gebruik-van-studiedata-en-ai',
+      },
     ],
   },
   {
     group: 'MBO_HBO_WO',
     docs: [
-      { id: 'npuls-visie-toetsing', title: 'Npuls: Visie op Toetsing & Examinering', path: '/docs/npuls-visie-toetsing.pdf' },
-      { id: 'npuls-handreiking-1', title: 'Npuls Handreiking 1', path: '/docs/npuls-handreiking-1.pdf' },
+      {
+        id: 'npuls-visie-toetsing',
+        title: 'Npuls: Visie op Toetsing & Examinering',
+        path: 'https://npuls.nl/kennisbank/visie-op-toetsing-examinering-en-ai-handreikingen',
+      },
+      {
+        id: 'npuls-handreiking-1',
+        title: 'Npuls Handreiking 1',
+        path: 'https://npuls.nl/kennisbank/visie-op-toetsing-examinering-en-ai-handreikingen',
+      },
       { id: 'npuls-handreiking-2', title: 'Npuls Handreiking 2', path: '/docs/npuls-handreiking-2.pdf' },
       { id: 'npuls-handreiking-3', title: 'Npuls Handreiking 3', path: '/docs/npuls-handreiking-3.pdf' },
       { id: 'npuls-handreiking-4', title: 'Npuls Handreiking 4', path: '/docs/npuls-handreiking-4.pdf' },
-      { id: 'ai-go', title: 'AI-GO: Raamwerk AI-geletterdheid', path: '/docs/ai-go.pdf' },
-      { id: 'referentiekader-2', title: 'Referentiekader 2.0', path: '/docs/referentiekader-2.pdf' },
+      {
+        id: 'ai-go',
+        title: 'AI-GO: Raamwerk AI-geletterdheid',
+        path: 'https://npuls.nl/kennisbank/ai-go-een-raamwerk-voor-ai-geletterdheid-in-het-onderwijs',
+      },
+      {
+        id: 'referentiekader-2',
+        title: 'Referentiekader 2.0',
+        path: 'https://npuls.nl/kennisbank/referentiekader-2-0-verantwoord-gebruik-van-studiedata-en-ai',
+      },
     ],
   },
 ];

--- a/Leerdoelengenerator-main/src/content/handreikingen.ts
+++ b/Leerdoelengenerator-main/src/content/handreikingen.ts
@@ -4,19 +4,19 @@ export const HANDREIKINGEN: HandreikingItem[] = [
   {
     id: 'npuls-visie-toetsing',
     titel: 'Visie op toetsing en examinering (AI-bewust)',
-    url: 'https://npuls.nl/visie-toetsing-examinering', // interne router/redirect indien gewenst
+    url: 'https://npuls.nl/kennisbank/visie-op-toetsing-examinering-en-ai-handreikingen', // interne router/redirect indien gewenst
     type: 'VISIE',
   },
   {
     id: 'npuls-handreiking-toetsing-1',
     titel: 'Handreiking Toetsing & Examinering — Handreiking 1',
-    url: 'https://npuls.nl/handreiking-ai-toetsing-1',
+    url: 'https://npuls.nl/kennisbank/visie-op-toetsing-examinering-en-ai-handreikingen',
     type: 'HANDREIKING',
   },
   {
     id: 'npuls-referentiekader-2-0',
     titel: 'Referentiekader 2.0 — Verantwoord studiedata & AI',
-    url: 'https://npuls.nl/referentiekader-ai-data',
+    url: 'https://npuls.nl/kennisbank/referentiekader-2-0-verantwoord-gebruik-van-studiedata-en-ai',
     type: 'REFERENTIEKADER',
   }
 ];

--- a/Leerdoelengenerator-main/src/core/education/scope-and-sources.ts
+++ b/Leerdoelengenerator-main/src/core/education/scope-and-sources.ts
@@ -75,14 +75,14 @@ const BEROEP_SOURCES: SourceBundle = {
         'Visie op toetsing en examinering in het tijdperk van AI (Npuls, 2025)',
       publisher: 'Npuls',
       year: '2025',
-      url: '/docs/npuls/visie-toetsing-ai.pdf',
+      url: 'https://npuls.nl/kennisbank/visie-op-toetsing-examinering-en-ai-handreikingen',
     },
     {
       id: 'npuls-handreiking-1',
       title: 'Handreiking 1: Toetsing en examinering in het tijdperk van AI',
       publisher: 'Npuls',
       year: '2025',
-      url: '/docs/npuls/handreiking-1.pdf',
+      url: 'https://npuls.nl/kennisbank/visie-op-toetsing-examinering-en-ai-handreikingen',
     },
     {
       id: 'npuls-handreiking-2',
@@ -110,14 +110,14 @@ const BEROEP_SOURCES: SourceBundle = {
       title: 'AI-GO! Raamwerk AI-geletterdheid (Npuls, 2025)',
       publisher: 'Npuls',
       year: '2025',
-      url: '/docs/npuls/ai-go.pdf',
+      url: 'https://npuls.nl/kennisbank/ai-go-een-raamwerk-voor-ai-geletterdheid-in-het-onderwijs',
     },
     {
       id: 'npuls-referentiekader-2.0-2025',
       title: 'Referentiekader 2.0 Verantwoord gebruik studiedata & AI (Npuls)',
       publisher: 'Npuls',
       year: '2025',
-      url: '/docs/npuls/referentiekader-2.0.pdf',
+      url: 'https://npuls.nl/kennisbank/referentiekader-2-0-verantwoord-gebruik-van-studiedata-en-ai',
     },
   ],
 };


### PR DESCRIPTION
## Summary
- replace placeholder Npuls URLs with official knowledge-base links for vision, handreiking, AI-GO, and Referentiekader
- align generator source bundles with updated Npuls links

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing ESLint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b62ce6cc8330ae50939dd0301e4d