### PR TITLE
Replace debug info with sector examples heading

### DIFF
--- a/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
+++ b/Leerdoelengenerator-main/src/features/examples/Voorbeeldcases.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
-import { getAllVoorbeeldcases, getSectorCounts /*, getCasesBySector */ } from '@/lib/examples';
+import { getAllVoorbeeldcases /*, getCasesBySector */ } from '@/lib/examples';
 import type { VoorbeeldCase } from '@/lib/examples';
-import { compareByLevel, LevelKey } from '@/utils/levelOrder';
+import { compareByLevel } from '@/utils/levelOrder';
 import { filterBySectorOrCategory, Sector } from '@/core/education/ui-adapters';
 
 export default function Voorbeeldcases({ currentSector, debug = false, onSelect }:{
@@ -14,17 +14,12 @@ export default function Voorbeeldcases({ currentSector, debug = false, onSelect 
     return currentSector ? filterBySectorOrCategory(all, currentSector as Sector) : all;
   }, [currentSector]);
 
-  const counts = getSectorCounts();
-  const countsLine = (['WO','HBO','MBO','VO','VSO','PO','SO'] as LevelKey[])
-    .map((lvl) => `${lvl}:${counts[lvl] ?? 0}`)
-    .join(' • ');
 
   return (
     <div className="space-y-2">
       {debug && (
         <div className="text-xs text-gray-600 p-2 border rounded">
-          <div className="font-semibold mb-1">Overkoepelende kaders & visies</div>
-          <div>{countsLine}</div>
+          <div className="font-semibold">Voorbeelden per sector</div>
         </div>
       )}
       {cases.map((c) => (


### PR DESCRIPTION
## Summary
- Replace debug block text with "Voorbeelden per sector"

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cc58a0488330aa6a768d041632c5