### PR TITLE
feat: expand templates with onderwijsType filter and Two-Lane badges

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { KDImport } from "./components/KDImport";
 import { SavedObjectives } from "./components/SavedObjectives";
 import { TemplateLibrary } from "./components/TemplateLibrary";
+import type { TemplateItem } from '@/types';
 import { Hero } from "./components/Hero";
 import Voorbeeldcases from "@/features/examples/Voorbeeldcases";
 import type { VoorbeeldCase } from "@/lib/examples";
@@ -721,10 +722,15 @@ function App() {
     setShowSavedObjectives(false);
   };
 
-  const useTemplate = (template: any) => {
+  const useTemplate = (template: TemplateItem) => {
     setFormData({
-      original: template.originalObjective,
-      context: { education: template.education, level: template.level, domain: template.domain, assessment: "" },
+      original: template.origineelLeerdoel,
+      context: {
+        education: template.sector,
+        level: template.niveau ?? '',
+        domain: template.leergebied,
+        assessment: "",
+      },
     });
     setShowTemplateLibrary(false);
   };

--- a/Leerdoelengenerator-main/src/components/TemplateLibrary.tsx
+++ b/Leerdoelengenerator-main/src/components/TemplateLibrary.tsx
@@ -1,194 +1,25 @@
 import React, { useState } from 'react';
-import { BookOpen, Copy, Star, Filter, Search, X, Award } from 'lucide-react';
-
-interface Template {
-  id: string;
-  title: string;
-  category: string;
-  education: string;
-  level: string;
-  domain: string;
-  originalObjective: string;
-  aiReadyObjective: string;
-  rationale: string;
-  activities: string[];
-  assessments: string[];
-  popularity: number;
-  qualityScore: number;
-}
+import { Copy, Search, X, Star, Award } from 'lucide-react';
+import { templates } from '@/data/templates';
+import type { TemplateItem, OnderwijsType } from '@/types';
 
 interface TemplateLibraryProps {
-  onUseTemplate: (template: Template) => void;
+  onUseTemplate: (template: TemplateItem) => void;
   onClose: () => void;
 }
 
 export function TemplateLibrary({ onUseTemplate, onClose }: TemplateLibraryProps) {
   const [searchTerm, setSearchTerm] = useState('');
-  const [filterCategory, setFilterCategory] = useState('');
-  const [filterEducation, setFilterEducation] = useState('');
+  const [typeFilter, setTypeFilter] = useState<'ALL' | OnderwijsType>('ALL');
 
-  const templates: Template[] = [
-    {
-      id: '1',
-      title: 'Zakelijke Communicatie',
-      category: 'Communicatie',
-      education: 'MBO',
-      level: 'Niveau 3',
-      domain: 'Secretarieel',
-      originalObjective: 'De student kan een zakelijke e-mail schrijven in correct Nederlands.',
-      aiReadyObjective: 'De student kan met hulp van AI-tools een zakelijke e-mail maken, de AI-tekst controleren en verbeteren, en zelf de juiste toon kiezen voor de ontvanger.',
-      rationale: 'In het werk van secretarieel worden AI-tools steeds gewoner. Studenten moeten leren hoe ze AI kunnen gebruiken als hulpmiddel, maar ook hoe ze de resultaten kunnen controleren.',
-      activities: [
-        'Probeer verschillende AI-tools uit voor e-mail schrijven',
-        'Werk samen met een klasgenoot om AI-teksten te controleren',
-        'Oefen met het verbeteren van AI-output',
-        'Laat zien hoe je AI hebt gebruikt in je werk'
-      ],
-      assessments: [
-        'Praktijkopdracht waarin je laat zien hoe je AI gebruikt en waarom',
-        'Portfolio met voorbeelden van je werk met AI',
-        'Gesprek over hoe je AI hebt gebruikt'
-      ],
-      popularity: 95,
-      qualityScore: 88
-    },
-    {
-      id: '2',
-      title: 'Marktonderzoek',
-      category: 'Onderzoek',
-      education: 'HBO',
-      level: 'Bachelor',
-      domain: 'Marketing',
-      originalObjective: 'De student kan een marktanalyse uitvoeren voor een nieuwe product.',
-      aiReadyObjective: 'De student kan een marktanalyse maken waarbij AI-tools helpen met data verzamelen, de AI-resultaten controleren op juistheid, en zelf conclusies trekken voor het product.',
-      rationale: 'In de moderne beroepspraktijk van marketing wordt AI een belangrijk hulpmiddel. Studenten moeten leren samenwerken met AI-technologie terwijl ze hun eigen vakkennis behouden.',
-      activities: [
-        'Gebruik verschillende AI-tools voor marktonderzoek en vergelijk de resultaten',
-        'Werk in duo\'s om AI-gegenereerde resultaten te evalueren',
-        'Voer een analyse uit van AI-output en leg je keuzes uit',
-        'Presenteer je werkproces met uitleg over AI-gebruik'
-      ],
-      assessments: [
-        'Praktijkopdracht waarin je het volledige werkproces toont inclusief AI-gebruik',
-        'Portfolio met reflectie op AI-inzet en gemaakte keuzes',
-        'Gesprek over evaluatie van AI-output'
-      ],
-      popularity: 88,
-      qualityScore: 85
-    },
-    {
-      id: '3',
-      title: 'Zorgplan Maken',
-      category: 'Zorgverlening',
-      education: 'MBO',
-      level: 'Niveau 4',
-      domain: 'Verpleegkunde',
-      originalObjective: 'De student kan een individueel zorgplan opstellen.',
-      aiReadyObjective: 'De student kan met hulp van AI-tools een zorgplan maken, de AI-suggesties controleren op veiligheid en geschiktheid, en het plan zelf aanpassen aan de specifieke patiënt.',
-      rationale: 'In de zorgverlening worden AI-tools steeds gewoner. Studenten moeten leren hoe ze AI kunnen gebruiken als hulpmiddel, maar ook hoe ze de resultaten kunnen controleren op veiligheid.',
-      activities: [
-        'Probeer verschillende AI-tools uit voor zorgplanning',
-        'Werk samen om AI-suggesties te controleren',
-        'Oefen met het aanpassen van AI-output aan patiënten',
-        'Bespreek wanneer AI wel en niet handig is in de zorg'
-      ],
-      assessments: [
-        'Praktijkopdracht waarin je laat zien hoe je AI gebruikt voor zorgplanning',
-        'Portfolio met voorbeelden van zorgplannen met AI-hulp',
-        'Gesprek over veiligheid bij AI-gebruik in de zorg'
-      ],
-      popularity: 92,
-      qualityScore: 90
-    },
-    {
-      id: '4',
-      title: 'Website Bouwen',
-      category: 'Techniek',
-      education: 'MBO',
-      level: 'Niveau 4',
-      domain: 'ICT',
-      originalObjective: 'De student kan een webapplicatie ontwikkelen volgens moderne standaarden.',
-      aiReadyObjective: 'De student kan een website maken met hulp van AI-tools voor code schrijven, de AI-code controleren en testen, en zelf verbeteringen maken waar nodig.',
-      rationale: 'In de ICT-sector worden AI-tools steeds gewoner voor programmeren. Studenten moeten leren hoe ze AI kunnen gebruiken als hulpmiddel, maar ook hoe ze de code kunnen controleren.',
-      activities: [
-        'Gebruik AI-tools voor het schrijven van code',
-        'Werk samen om AI-gegenereerde code te controleren',
-        'Oefen met het testen en verbeteren van AI-code',
-        'Leer hoe AI-tools werken en wat hun beperkingen zijn'
-      ],
-      assessments: [
-        'Praktijkopdracht waarin je een werkende website toont met AI-hulp',
-        'Portfolio met code-voorbeelden en uitleg over AI-gebruik',
-        'Presentatie over je ontwikkelproces'
-      ],
-      popularity: 90,
-      qualityScore: 87
-    },
-    {
-      id: '5',
-      title: 'Klantgesprek Voeren',
-      category: 'Communicatie',
-      education: 'MBO',
-      level: 'Niveau 3',
-      domain: 'Verkoop',
-      originalObjective: 'De student kan een klantgesprek voeren.',
-      aiReadyObjective: 'De student kan een klantgesprek voorbereiden met hulp van AI-tools voor klantinformatie, de AI-tips controleren en gebruiken, en zelf het gesprek voeren op een persoonlijke manier.',
-      rationale: 'In de verkoop worden AI-tools steeds gewoner voor klantanalyse. Studenten moeten leren hoe ze AI kunnen gebruiken voor voorbereiding, maar het echte gesprek blijft menselijk werk.',
-      activities: [
-        'Gebruik AI-tools voor klantanalyse en gespreksvoorbereiding',
-        'Werk samen om AI-tips te controleren en verbeteren',
-        'Oefen gesprekken waarin AI-informatie wordt gebruikt',
-        'Bespreek wanneer AI wel en niet handig is bij klantcontact'
-      ],
-      assessments: [
-        'Praktijkopdracht waarin je een klantgesprek voert met AI-voorbereiding',
-        'Portfolio met voorbeelden van gespreksvoorbereidingen',
-        'Gesprek over hoe AI je werk kan verbeteren'
-      ],
-      popularity: 85,
-      qualityScore: 83
-    },
-    {
-      id: '6',
-      title: 'Project Plannen',
-      category: 'Management',
-      education: 'MBO',
-      level: 'Niveau 4',
-      domain: 'Bedrijfskunde',
-      originalObjective: 'De student kan een project plannen en uitvoeren.',
-      aiReadyObjective: 'De student kan een project plannen met hulp van AI-tools voor planning en risico\'s, de AI-suggesties controleren en aanpassen, en zelf het project leiden en bijsturen.',
-      rationale: 'In projectmanagement worden AI-tools steeds gewoner voor planning en analyse. Studenten moeten leren hoe ze AI kunnen gebruiken als hulpmiddel, maar zelf de leiding houden.',
-      activities: [
-        'Gebruik AI-tools voor projectplanning en risicoanalyse',
-        'Werk samen om AI-planningen te controleren en verbeteren',
-        'Oefen met het bijsturen van projecten met AI-ondersteuning',
-        'Bespreek de rol van AI in teamleiding'
-      ],
-      assessments: [
-        'Praktijkopdracht waarin je een project plant en uitvoert met AI-hulp',
-        'Portfolio met planningen en evaluaties',
-        'Presentatie over projectresultaten en AI-gebruik'
-      ],
-      popularity: 87,
-      qualityScore: 85
-    }
-  ];
+  const filteredTemplates = templates.filter((t) =>
+    (typeFilter === 'ALL' || t.onderwijsType === typeFilter) &&
+    t.titel.toLowerCase().includes(searchTerm.toLowerCase())
+  );
 
-  const filteredTemplates = templates.filter(template => {
-    const matchesSearch = template.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         template.domain.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         template.originalObjective.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesCategory = !filterCategory || template.category === filterCategory;
-    const matchesEducation = !filterEducation || template.education === filterEducation;
-    
-    return matchesSearch && matchesCategory && matchesEducation;
-  });
-
-  // Sort by quality score
-  const sortedTemplates = filteredTemplates.sort((a, b) => b.qualityScore - a.qualityScore);
-
-  const categories = [...new Set(templates.map(t => t.category))];
-  const educationTypes = [...new Set(templates.map(t => t.education))];
+  const sortedTemplates = filteredTemplates.sort(
+    (a, b) => (b.kwaliteit ?? 0) - (a.kwaliteit ?? 0)
+  );
 
   const getQualityColor = (score: number) => {
     if (score >= 85) return 'text-green-600';
@@ -202,9 +33,12 @@ export function TemplateLibrary({ onUseTemplate, onClose }: TemplateLibraryProps
     return 'bg-red-100';
   };
 
+  const laneLabel = (baan: 1 | 2) =>
+    baan === 1 ? 'Baan 1 (AI-bewust)' : 'Baan 2 (AI-geletterd)';
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-7xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+      <div className="bg-white rounded-xl shadow-xl max-w-5xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         <div className="p-6 border-b border-gray-200 flex justify-between items-center">
           <h2 className="text-xl font-semibold bg-gradient-to-r from-green-600 to-orange-500 bg-clip-text text-transparent flex items-center">
             <Award className="w-5 h-5 text-green-600 mr-2" />
@@ -218,9 +52,8 @@ export function TemplateLibrary({ onUseTemplate, onClose }: TemplateLibraryProps
           </button>
         </div>
 
-        {/* Filters */}
         <div className="p-6 border-b border-gray-100 bg-gradient-to-r from-green-50 to-orange-50">
-          <div className="grid md:grid-cols-3 gap-4">
+          <div className="grid md:grid-cols-2 gap-4">
             <div className="relative">
               <Search className="w-4 h-4 absolute left-3 top-3 text-gray-400" />
               <input
@@ -231,57 +64,60 @@ export function TemplateLibrary({ onUseTemplate, onClose }: TemplateLibraryProps
                 className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
               />
             </div>
-            
-            <select
-              value={filterCategory}
-              onChange={(e) => setFilterCategory(e.target.value)}
-              className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
-            >
-              <option value="">Alle categorieën</option>
-              {categories.map(category => (
-                <option key={category} value={category}>{category}</option>
-              ))}
-            </select>
 
             <select
-              value={filterEducation}
-              onChange={(e) => setFilterEducation(e.target.value)}
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value as 'ALL' | OnderwijsType)}
               className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
             >
-              <option value="">Alle onderwijstypes</option>
-              {educationTypes.map(type => (
-                <option key={type} value={type}>{type}</option>
-              ))}
+              <option value="ALL">Alle onderwijstypes</option>
+              <option value="FUNDEREND">Funderend</option>
+              <option value="BEROEPS">Beroepsonderwijs</option>
             </select>
           </div>
         </div>
 
-        {/* Templates Grid */}
         <div className="flex-1 overflow-y-auto p-6">
           <div className="grid lg:grid-cols-2 gap-6">
             {sortedTemplates.map((template) => (
-              <div key={template.id} className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
+              <div
+                key={template.id}
+                className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow"
+              >
                 <div className="flex justify-between items-start mb-4">
                   <div className="flex-1">
-                    <h3 className="text-lg font-semibold text-gray-900 mb-2">{template.title}</h3>
+                    <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                      {template.titel}
+                    </h3>
                     <div className="flex items-center space-x-2 text-sm text-gray-600 mb-2">
                       <span className="bg-gradient-to-r from-green-100 to-orange-100 text-green-800 px-2 py-1 rounded border border-green-200">
-                        {template.category}
+                        {template.sector}
                       </span>
-                      <span>{template.education} - {template.level}</span>
+                      {template.niveau && (
+                        <>
+                          <span>•</span>
+                          <span>{template.niveau}</span>
+                        </>
+                      )}
                       <span>•</span>
-                      <span>{template.domain}</span>
+                      <span>{template.leergebied}</span>
                     </div>
                   </div>
                   <div className="flex flex-col items-end space-y-2">
-                    <div className="flex items-center space-x-1">
-                      <Star className="w-4 h-4 text-orange-500 fill-current" />
-                      <span className="text-sm font-medium text-gray-700">{template.popularity}%</span>
-                    </div>
-                    <div className={`px-2 py-1 rounded text-xs font-medium ${getQualityBackground(template.qualityScore)}`}>
-                      <span className={getQualityColor(template.qualityScore)}>
-                        Kwaliteit: {template.qualityScore}%
-                      </span>
+                    {template.kwaliteit !== undefined && (
+                      <div
+                        className={`px-2 py-1 rounded text-xs font-medium ${getQualityBackground(
+                          template.kwaliteit
+                        )}`}
+                      >
+                        <span className={getQualityColor(template.kwaliteit)}>
+                          <Star className="w-4 h-4 text-orange-500 inline mr-1" />
+                          Kwaliteit: {template.kwaliteit}%
+                        </span>
+                      </div>
+                    )}
+                    <div className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">
+                      {laneLabel(template.baan)}
                     </div>
                   </div>
                 </div>
@@ -289,12 +125,16 @@ export function TemplateLibrary({ onUseTemplate, onClose }: TemplateLibraryProps
                 <div className="space-y-3 mb-4">
                   <div>
                     <p className="text-sm font-medium text-red-700 mb-1">Origineel leerdoel:</p>
-                    <p className="text-sm text-gray-700">{template.originalObjective}</p>
+                    <p className="text-sm text-gray-700">
+                      {template.origineelLeerdoel}
+                    </p>
                   </div>
-                  
+
                   <div>
                     <p className="text-sm font-medium text-green-700 mb-1">AI-ready (Eenvoudiger):</p>
-                    <p className="text-sm text-gray-700">{template.aiReadyObjective}</p>
+                    <p className="text-sm text-gray-700">
+                      {template.aiReadyLeerdoel}
+                    </p>
                   </div>
                 </div>
 
@@ -321,3 +161,4 @@ export function TemplateLibrary({ onUseTemplate, onClose }: TemplateLibraryProps
     </div>
   );
 }
+

--- a/Leerdoelengenerator-main/src/data/templates.ts
+++ b/Leerdoelengenerator-main/src/data/templates.ts
@@ -1,0 +1,202 @@
+// ===== BEGIN: VOORBEELDEN PER SECTOR =====
+import { TemplateItem } from '../types';
+
+export const templates: TemplateItem[] = [
+  // --- PO (FUNDEREND) ---
+  {
+    id: 'po-tekst-feedback',
+    titel: 'PO • Creatieve tekst + AI-feedback',
+    sector: 'PO',
+    onderwijsType: 'FUNDEREND',
+    leergebied: 'DG',
+    niveau: 'PO',
+    kwaliteit: 90,
+    baan: 1,
+    origineelLeerdoel: 'De leerling kan een korte creatieve tekst schrijven met een begin, midden en eind.',
+    aiReadyLeerdoel: 'De leerling schrijft een korte creatieve tekst en gebruikt een AI-tool voor taaltips; de leerling verwerkt de relevante suggesties en licht dat toe.',
+    korteBeschrijving: 'AI als feedbackpartner; nadruk op eigen werk en reflectie (baan 1).'
+  },
+  {
+    id: 'po-burgerschap-nieuws',
+    titel: 'PO • Nieuws & nepnieuws met AI',
+    sector: 'PO',
+    onderwijsType: 'FUNDEREND',
+    leergebied: 'BURGERSCHAP',
+    niveau: 'PO',
+    kwaliteit: 88,
+    baan: 1,
+    origineelLeerdoel: 'De leerling kan bronnen over een actueel onderwerp vergelijken.',
+    aiReadyLeerdoel: 'De leerling vergelijkt nieuwsbronnen, gebruikt AI voor samenvattingen en benoemt eigen checks op betrouwbaarheid en bias.',
+    korteBeschrijving: 'Mediawijsheid; AI-inzet transparant en controleerbaar.'
+  },
+
+  // --- SO (FUNDEREND) ---
+  {
+    id: 'so-rekenen-hints',
+    titel: 'SO • Rekenroute met AI-hints',
+    sector: 'SO',
+    onderwijsType: 'FUNDEREND',
+    leergebied: 'ALGEMEEN',
+    niveau: 'SO',
+    kwaliteit: 86,
+    baan: 1,
+    origineelLeerdoel: 'De leerling kan een meerstaps rekenopgave oplossen.',
+    aiReadyLeerdoel: 'De leerling lost een meerstapsopgave op en gebruikt indien nodig AI-hints; de leerling legt de gekozen stappen zelf uit.',
+    korteBeschrijving: 'AI als scaffolding, leren staat centraal.'
+  },
+  {
+    id: 'so-dg-herkennen-ai',
+    titel: 'SO • Echt of AI-gegenereerd?',
+    sector: 'SO',
+    onderwijsType: 'FUNDEREND',
+    leergebied: 'DG',
+    niveau: 'SO',
+    kwaliteit: 84,
+    baan: 1,
+    origineelLeerdoel: 'De leerling kan digitale beelden beoordelen op echtheid.',
+    aiReadyLeerdoel: 'De leerling beoordeelt (AI)beelden en motiveert waarom iets echt of gegenereerd is; benoemt risico’s en veilig gebruik.',
+    korteBeschrijving: 'Basis digitale geletterdheid en veiligheid.'
+  },
+
+  // --- VSO (FUNDEREND) ---
+  {
+    id: 'vso-praktisch-plan',
+    titel: 'VSO • Praktisch stappenplan met AI',
+    sector: 'VSO',
+    onderwijsType: 'FUNDEREND',
+    leergebied: 'ALGEMEEN',
+    niveau: 'VSO',
+    kwaliteit: 85,
+    baan: 1,
+    origineelLeerdoel: 'De leerling kan een praktisch stappenplan volgen.',
+    aiReadyLeerdoel: 'De leerling maakt met AI-ondersteuning een passend stappenplan, voert het uit en reflecteert op veiligheid en zelfstandigheid.',
+    korteBeschrijving: 'Functioneel en context-nabij.'
+  },
+  {
+    id: 'vso-dg-veiligheid',
+    titel: 'VSO • Veilig online met AI-assistent',
+    sector: 'VSO',
+    onderwijsType: 'FUNDEREND',
+    leergebied: 'DG',
+    niveau: 'VSO',
+    kwaliteit: 83,
+    baan: 1,
+    origineelLeerdoel: 'De leerling kan veilig onlinegedrag tonen.',
+    aiReadyLeerdoel: 'De leerling gebruikt een AI-assistent om risico’s te herkennen (phishing, privacy) en kiest passende acties.',
+    korteBeschrijving: 'Veiligheid en zelfregie.'
+  },
+
+  // --- VO (FUNDEREND) ---
+  {
+    id: 'vo-nask-hypothese',
+    titel: 'VO • Hypothese toetsen met AI-analyse',
+    sector: 'VO',
+    onderwijsType: 'FUNDEREND',
+    leergebied: 'ALGEMEEN',
+    niveau: 'VO onderbouw',
+    kwaliteit: 89,
+    baan: 1,
+    origineelLeerdoel: 'De leerling kan een experiment uitvoeren en resultaten interpreteren.',
+    aiReadyLeerdoel: 'De leerling voert een experiment uit, gebruikt AI voor eerste patroonherkenning en controleert/weerlegt met eigen berekeningen.',
+    korteBeschrijving: 'AI als hulpmiddel, leerling verantwoordt eigen keuzes.'
+  },
+  {
+    id: 'vo-burgerschap-ai-ethiek',
+    titel: 'VO • Debat: AI-ethiek in de samenleving',
+    sector: 'VO',
+    onderwijsType: 'FUNDEREND',
+    leergebied: 'BURGERSCHAP',
+    niveau: 'VO onderbouw',
+    kwaliteit: 87,
+    baan: 1,
+    origineelLeerdoel: 'De leerling kan standpunten onderbouwen in een debat.',
+    aiReadyLeerdoel: 'De leerling bereidt een debat voor met AI-samenvattingen, controleert bronnen, en verantwoordt de rol van AI in de argumentatie.',
+    korteBeschrijving: 'Transparantie over AI-gebruik (baan 1).'
+  },
+
+  // --- MBO (BEROEPS) ---
+  {
+    id: 'mbo-zorg-dilemma',
+    titel: 'MBO • Zorg: Praktijksituatie & AI-advies',
+    sector: 'MBO',
+    onderwijsType: 'BEROEPS',
+    leergebied: 'ZORG',
+    niveau: 'MBO • Niveau 3-4',
+    kwaliteit: 92,
+    baan: 2,
+    origineelLeerdoel: 'De student kan een zorgplan opstellen voor een cliëntsituatie.',
+    aiReadyLeerdoel: 'De student stelt met AI-ondersteuning een zorgplan op, controleert veiligheid/geschiktheid en verantwoordt keuzes volgens richtlijnen.',
+    korteBeschrijving: 'AI-geletterd handelen in context (baan 2).'
+  },
+  {
+    id: 'mbo-verkopen-klantgesprek',
+    titel: 'MBO • Commercie: Klantgesprek met AI-briefing',
+    sector: 'MBO',
+    onderwijsType: 'BEROEPS',
+    leergebied: 'COMMUNICATIE',
+    niveau: 'MBO • Niveau 3',
+    kwaliteit: 88,
+    baan: 2,
+    origineelLeerdoel: 'De student kan een klantgesprek voorbereiden en uitvoeren.',
+    aiReadyLeerdoel: 'De student gebruikt AI om een klantbriefing te genereren, checkt juistheid, en voert het gesprek professioneel met eigen documentatie.',
+    korteBeschrijving: 'AI als assistent, student beslist.'
+  },
+
+  // --- HBO (BEROEPS) ---
+  {
+    id: 'hbo-dg-data-ethiek',
+    titel: 'HBO • DG: Data-ethiek & bronvermelding',
+    sector: 'HBO',
+    onderwijsType: 'BEROEPS',
+    leergebied: 'DG',
+    niveau: 'HBO • Ba',
+    kwaliteit: 90,
+    baan: 2,
+    origineelLeerdoel: 'De student kan bronnen verantwoord gebruiken in beroepsproducten.',
+    aiReadyLeerdoel: 'De student zet AI in voor literatuurzoektochten, controleert betrouwbaarheid, citeert correct en verantwoordt AI-bijdragen.',
+    korteBeschrijving: 'Transparantie conform AI-GO / Npuls.'
+  },
+  {
+    id: 'hbo-project-plannen',
+    titel: 'HBO • Projectmanagement met AI-risicoanalyse',
+    sector: 'HBO',
+    onderwijsType: 'BEROEPS',
+    leergebied: 'MANAGEMENT',
+    niveau: 'HBO • Ba',
+    kwaliteit: 87,
+    baan: 2,
+    origineelLeerdoel: 'De student kan een projectplan opstellen en uitvoeren.',
+    aiReadyLeerdoel: 'De student gebruikt AI voor risico-/planning-suggesties, valideert aannames en stuurt bij met onderbouwde beslissingen.',
+    korteBeschrijving: 'AI-assisted, mens beslist.'
+  },
+
+  // --- WO (BEROEPS) ---
+  {
+    id: 'wo-ai-ethiek-paper',
+    titel: 'WO • AI-ethiek: position paper + bronkritiek',
+    sector: 'WO',
+    onderwijsType: 'BEROEPS',
+    leergebied: 'BURGERSCHAP',
+    niveau: 'WO • Master',
+    kwaliteit: 91,
+    baan: 2,
+    origineelLeerdoel: 'De student kan een academisch betoog schrijven.',
+    aiReadyLeerdoel: 'De student gebruikt AI voor concept-tegenargumenten, checkt hallucinaties, en levert een paper met expliciete AI-verantwoording.',
+    korteBeschrijving: 'Academische integriteit met AI.'
+  },
+  {
+    id: 'wo-onderzoek-marktdata',
+    titel: 'WO • Onderzoek: Marktdata & AI-analyse',
+    sector: 'WO',
+    onderwijsType: 'BEROEPS',
+    leergebied: 'ONDERZOEK',
+    niveau: 'WO • Bachelor/Master',
+    kwaliteit: 88,
+    baan: 2,
+    origineelLeerdoel: 'De student kan een marktanalyse uitvoeren.',
+    aiReadyLeerdoel: 'De student gebruikt AI voor dataset-opschoning/samenvattingen en voert de kernanalyses en interpretatie zelfstandig en reproduceerbaar uit.',
+    korteBeschrijving: 'AI versnelt, student interpreteert.'
+  },
+];
+// ===== END: VOORBEELDEN PER SECTOR =====
+

--- a/Leerdoelengenerator-main/src/types.ts
+++ b/Leerdoelengenerator-main/src/types.ts
@@ -1,4 +1,20 @@
-export type Sector = 'PO'|'SO'|'VO'|'VSO'|'MBO'|'HBO'|'WO';
+export type Sector = 'PO'|'SO'|'VSO'|'VO'|'MBO'|'HBO'|'WO';
+export type OnderwijsType = 'FUNDEREND' | 'BEROEPS';
+export type Leergebied = 'BURGERSCHAP'|'DG'|'COMMUNICATIE'|'TECHNIEK'|'ONDERZOEK'|'MANAGEMENT'|'ZORG'|'ICT'|'ALGEMEEN';
+
+export interface TemplateItem {
+  id: string;
+  titel: string;
+  sector: Sector;
+  onderwijsType: OnderwijsType; // nieuw: filter “Alle onderwijstypes”
+  leergebied: Leergebied;
+  niveau?: string;               // bijv. “MBO • Niveau 3”
+  kwaliteit?: number;            // 0–100, voor badge
+  baan: 1|2;                     // Two-Lane: 1=AI-bewust (zonder/onder voorwaarden), 2=AI-geletterd (met AI)
+  origineelLeerdoel: string;
+  aiReadyLeerdoel: string;       // eenvoudigere, AI-ready versie
+  korteBeschrijving?: string;
+}
 
 export type LeergebiedKey = 'BURGERSCHAP'|'DG'; // DG = Digitale Geletterdheid
 
@@ -17,3 +33,4 @@ export interface HandreikingItem {
   url: string;
   type: 'VISIE'|'HANDREIKING'|'REFERENTIEKADER';
 }
+


### PR DESCRIPTION
## Summary
- define TemplateItem with onderwijsType and Two-Lane metadata
- add 14 templates across sectors with quality scores
- filter templates by onderwijsType and show lane badges

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d26e98f88330b7ca247e47ca4b0d