### PR TITLE
Sanitize document title to remove DigitEd suffix

### DIFF
--- a/Leerdoelengenerator-main/src/components/RouteTracker.tsx
+++ b/Leerdoelengenerator-main/src/components/RouteTracker.tsx
@@ -2,12 +2,22 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { sendPageView } from '@/lib/ga';
 
+const DIGITED_SUFFIX = /\s*\|?\s*DigitEd\s*$/i;
+const DEFAULT_TITLE = 'AI Leerdoelenmaker';
+
 export default function RouteTracker() {
   const location = useLocation();
 
   useEffect(() => {
+    const currentTitle = document.title;
+    const sanitizedTitle = currentTitle.replace(DIGITED_SUFFIX, '').trim() || DEFAULT_TITLE;
+
+    if (sanitizedTitle !== currentTitle) {
+      document.title = sanitizedTitle;
+    }
+
     // Consent-status bepaalt vanzelf of dit cookieless of enhanced is
-    sendPageView(location.pathname, document.title);
+    sendPageView(location.pathname, sanitizedTitle);
   }, [location]);
 
   return null;


### PR DESCRIPTION
## Summary
- strip any trailing "DigitEd" suffix from the document title whenever the route changes
- ensure Google Analytics receives the cleaned title when tracking page views

## Testing
- npm install *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/glob)*

------
https://chatgpt.com/codex/tasks/task_e_68c85f5188448330b352d2542771bcfd