### PR TITLE
feat: add toetsvorm search modal

### DIFF
--- a/Leerdoelengenerator-main/src/App.tsx
+++ b/Leerdoelengenerator-main/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { KDImport } from "./components/KDImport";
 import { SavedObjectives } from "./components/SavedObjectives";
 import { TemplateLibrary } from "./components/TemplateLibrary";
+import ToetsvormSearchModal from "@/components/ToetsvormSearchModal";
 import type { TemplateItem } from '@/types';
 import { Hero } from "./components/Hero";
 import Voorbeeldcases from "@/features/examples/Voorbeeldcases";
@@ -268,6 +269,7 @@ function App() {
   const [showEducationGuidance, setShowEducationGuidance] = useState(false);
   const [generationSource, setGenerationSource] = useState<GenerationSource>(null); // NIEUW: bron van de laatste generatie
   const [menuOpen, setMenuOpen] = useState(false);
+  const [openToetsvormSearch, setOpenToetsvormSearch] = useState(false);
 
   const handleExampleSelect = (ex: VoorbeeldCase) => {
     setSector(ex.sector);
@@ -877,6 +879,14 @@ function App() {
                   <BookOpen className="w-4 h-4" />
                   <span>Begrippen</span>
                 </a>
+
+                <button
+                  onClick={() => setOpenToetsvormSearch(true)}
+                  className="flex items-center space-x-2 bg-indigo-600 text-white h-11 px-4 rounded-lg font-medium hover:bg-indigo-700 transition-all duration-200 shadow-md hover:shadow-lg"
+                >
+                  <span aria-hidden="true">🔎</span>
+                  <span>Zoek toetsvormen</span>
+                </button>
               </div>
 
               <button
@@ -929,10 +939,26 @@ function App() {
                 <BookOpen className="w-4 h-4" />
                 <span>Begrippen</span>
               </a>
+
+              <button
+                onClick={() => {
+                  setOpenToetsvormSearch(true);
+                  setMenuOpen(false);
+                }}
+                className="flex items-center justify-center space-x-2 bg-indigo-600 text-white h-11 px-4 rounded-lg font-medium hover:bg-indigo-700 transition-all duration-200 shadow-md hover:shadow-lg w-full"
+              >
+                <span aria-hidden="true">🔎</span>
+                <span>Zoek toetsvormen</span>
+              </button>
             </div>
           )}
         </div>
       </header>
+
+      <ToetsvormSearchModal
+        open={openToetsvormSearch}
+        onClose={() => setOpenToetsvormSearch(false)}
+      />
 
       <Hero />
       <div id="form-start" className="max-w-screen-xl mx-auto px-4 lg:px-8 py-8 space-y-6">

--- a/Leerdoelengenerator-main/src/components/ToetsvormSearchModal.tsx
+++ b/Leerdoelengenerator-main/src/components/ToetsvormSearchModal.tsx
@@ -1,0 +1,158 @@
+// === BEGIN: src/components/ToetsvormSearchModal.tsx ===
+"use client";
+import React, { useEffect } from "react";
+import { useToetsvormSearch } from "@/hooks/useToetsvormSearch";
+import { ToetsCategorie } from "@/data/toetsvormen";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function ToetsvormSearchModal({ open, onClose }: Props) {
+  const {
+    query,
+    setQuery,
+    activeCats,
+    toggleCat,
+    onlyBaan,
+    setOnlyBaan,
+    categories,
+    results,
+  } = useToetsvormSearch();
+
+  useEffect(() => {
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    if (open) window.addEventListener("keydown", onEsc);
+    return () => window.removeEventListener("keydown", onEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-start justify-center bg-black/50 p-4 md:p-8">
+      <div className="w-full max-w-4xl rounded-2xl bg-white p-4 md:p-6 shadow-xl">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-xl md:text-2xl font-semibold">Zoek toetsvormen</h2>
+          <button
+            onClick={onClose}
+            className="rounded-full p-2 hover:bg-gray-100"
+            aria-label="Sluiten"
+            title="Sluiten"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Zoekbalk */}
+        <div className="mt-4">
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Zoeken op naam of beschrijving…"
+            className="w-full rounded-xl border border-gray-300 px-4 py-3 outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+
+        {/* Filters */}
+        <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="md:col-span-2">
+            <p className="mb-2 text-sm font-medium text-gray-700">Categorieën</p>
+            <div className="flex flex-wrap gap-2">
+              {categories.map((c: ToetsCategorie) => {
+                const active = activeCats.includes(c);
+                return (
+                  <button
+                    key={c}
+                    onClick={() => toggleCat(c)}
+                    className={[
+                      "rounded-full border px-3 py-1 text-sm",
+                      active
+                        ? "border-indigo-600 bg-indigo-600 text-white"
+                        : "border-gray-300 bg-white text-gray-800 hover:bg-gray-50",
+                    ].join(" ")}
+                    aria-pressed={active}
+                  >
+                    {c}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-2 text-sm font-medium text-gray-700">Two-Lane (optioneel)</p>
+            <select
+              value={onlyBaan}
+              onChange={(e) =>
+                setOnlyBaan(
+                  e.target.value as "" | "Baan 1" | "Baan 2" | "Beide"
+                )
+              }
+              className="w-full rounded-xl border border-gray-300 px-3 py-2 outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <option value="">Alle</option>
+              <option value="Baan 1">Baan 1</option>
+              <option value="Baan 2">Baan 2</option>
+              <option value="Beide">Beide</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Resultaten */}
+        <div className="mt-6">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-gray-600">
+              {results.length} resultaat{results.length === 1 ? "" : "en"}
+            </p>
+          </div>
+
+          <ul className="mt-3 divide-y divide-gray-200 rounded-xl border border-gray-200">
+            {results.map((t) => (
+              <li key={t.id} className="p-4">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+                  <div>
+                    <h3 className="text-base md:text-lg font-semibold">{t.naam}</h3>
+                    {t.beschrijving && (
+                      <p className="mt-1 text-sm text-gray-700">{t.beschrijving}</p>
+                    )}
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {t.categorieen.map((c) => (
+                        <span
+                          key={c}
+                          className="rounded-full bg-gray-100 px-2.5 py-1 text-xs text-gray-800"
+                        >
+                          {c}
+                        </span>
+                      ))}
+                      {t.baan && (
+                        <span className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs text-indigo-700">
+                          {t.baan}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  {/* 👉 Voorzie van jouw eigen deep-link of actie */}
+                  <a
+                    href={`#toetsvorm-${t.id}`}
+                    className="inline-flex items-center justify-center rounded-lg border border-gray-300 px-3 py-2 text-sm hover:bg-gray-50"
+                  >
+                    Bekijken
+                  </a>
+                </div>
+              </li>
+            ))}
+            {results.length === 0 && (
+              <li className="p-6 text-center text-sm text-gray-600">
+                Geen resultaten. Pas je zoekterm of filters aan.
+              </li>
+            )}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+// === EIND: src/components/ToetsvormSearchModal.tsx ===

--- a/Leerdoelengenerator-main/src/data/toetsvormen.ts
+++ b/Leerdoelengenerator-main/src/data/toetsvormen.ts
@@ -1,0 +1,100 @@
+export type ToetsCategorie =
+  | "Mondeling"
+  | "Schriftelijk"
+  | "Praktijk/Authentiek"
+  | "Proces/Portfolio"
+  | "Digitaal/Geautomatiseerd"
+  | "Peer/Co-assessment";
+
+export interface Toetsvorm {
+  id: string;
+  naam: string;
+  beschrijving?: string;
+  categorieen: ToetsCategorie[];
+  baan?: "Baan 1" | "Baan 2" | "Beide"; // Npuls Two-Lane
+  validiteitFocus?: "Hoog" | "Midden" | "Laag";
+  betrouwbaarheidFocus?: "Hoog" | "Midden" | "Laag";
+}
+
+export const ALLE_CATEGORIEEN: ToetsCategorie[] = [
+  "Mondeling",
+  "Schriftelijk",
+  "Praktijk/Authentiek",
+  "Proces/Portfolio",
+  "Digitaal/Geautomatiseerd",
+  "Peer/Co-assessment",
+];
+
+// 🎯 Voorbeeldset — vervang/uitbreid met jouw eigen lijst
+export const TOETSVORMEN: Toetsvorm[] = [
+  {
+    id: "mondeling-examen",
+    naam: "Mondeling examen",
+    beschrijving:
+      "Individuele mondelinge bevraging met doorvragen op begrip en toepassing.",
+    categorieen: ["Mondeling"],
+    baan: "Baan 1",
+    validiteitFocus: "Hoog",
+    betrouwbaarheidFocus: "Midden",
+  },
+  {
+    id: "presentatie",
+    naam: "Presentatie (individueel of groep)",
+    beschrijving:
+      "Student presenteert resultaten, met vragenronde voor verantwoording.",
+    categorieen: ["Mondeling", "Praktijk/Authentiek"],
+    baan: "Beide",
+    validiteitFocus: "Hoog",
+    betrouwbaarheidFocus: "Midden",
+  },
+  {
+    id: "essay",
+    naam: "Essay / Verslag",
+    beschrijving:
+      "Schriftelijke uitwerking met nadruk op redenering, bronnen en structuur.",
+    categorieen: ["Schriftelijk"],
+    baan: "Baan 1",
+    validiteitFocus: "Midden",
+    betrouwbaarheidFocus: "Midden",
+  },
+  {
+    id: "praktijktoets",
+    naam: "Praktijktoets / Proeve van Bekwaamheid",
+    beschrijving:
+      "Authentieke beroepsopdracht in een realistische setting (stage/werkplek/simulatie).",
+    categorieen: ["Praktijk/Authentiek"],
+    baan: "Beide",
+    validiteitFocus: "Hoog",
+    betrouwbaarheidFocus: "Midden",
+  },
+  {
+    id: "portfolio",
+    naam: "Portfolio met reflectie/logboek",
+    beschrijving:
+      "Doorlopende verzameling van bewijsstukken met reflecties en feedback.",
+    categorieen: ["Proces/Portfolio"],
+    baan: "Beide",
+    validiteitFocus: "Hoog",
+    betrouwbaarheidFocus: "Midden",
+  },
+  {
+    id: "digitaal-auto",
+    naam: "Digitaal (automatisch nakijken)",
+    beschrijving:
+      "MC/gesloten vragen met automatische scoring en item-analyse.",
+    categorieen: ["Digitaal/Geautomatiseerd"],
+    baan: "Baan 1",
+    validiteitFocus: "Midden",
+    betrouwbaarheidFocus: "Hoog",
+  },
+  {
+    id: "peer-assessment",
+    naam: "Peer assessment",
+    beschrijving:
+      "Studenten beoordelen elkaars werk aan de hand van heldere criteria/rubrics.",
+    categorieen: ["Peer/Co-assessment", "Proces/Portfolio"],
+    baan: "Baan 2",
+    validiteitFocus: "Midden",
+    betrouwbaarheidFocus: "Midden",
+  },
+];

--- a/Leerdoelengenerator-main/src/hooks/useToetsvormSearch.ts
+++ b/Leerdoelengenerator-main/src/hooks/useToetsvormSearch.ts
@@ -1,0 +1,49 @@
+// === BEGIN: src/hooks/useToetsvormSearch.ts ===
+import { useMemo, useState } from "react";
+import { TOETSVORMEN, ALLE_CATEGORIEEN, Toetsvorm, ToetsCategorie } from "@/data/toetsvormen";
+
+export function useToetsvormSearch() {
+  const [query, setQuery] = useState("");
+  const [activeCats, setActiveCats] = useState<ToetsCategorie[]>([]);
+  const [onlyBaan, setOnlyBaan] = useState<"Baan 1" | "Baan 2" | "Beide" | "">("");
+
+  const results = useMemo<Toetsvorm[]>(() => {
+    const q = query.trim().toLowerCase();
+
+    return TOETSVORMEN.filter((t) => {
+      // tekstzoek: naam + beschrijving
+      const matchText =
+        !q ||
+        t.naam.toLowerCase().includes(q) ||
+        (t.beschrijving?.toLowerCase().includes(q) ?? false);
+
+      // categorie-filter (AND: alle gekozen categorieën moeten voorkomen)
+      const matchCats =
+        activeCats.length === 0 ||
+        activeCats.every((c) => t.categorieen.includes(c));
+
+      // baan-filter (optioneel)
+      const matchBaan = !onlyBaan || t.baan === onlyBaan || (onlyBaan === "Beide" && t.baan === "Beide");
+
+      return matchText && matchCats && matchBaan;
+    }).sort((a, b) => a.naam.localeCompare(b.naam));
+  }, [query, activeCats, onlyBaan]);
+
+  function toggleCat(cat: ToetsCategorie) {
+    setActiveCats((prev) =>
+      prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat]
+    );
+  }
+
+  return {
+    query,
+    setQuery,
+    activeCats,
+    toggleCat,
+    onlyBaan,
+    setOnlyBaan,
+    categories: ALLE_CATEGORIEEN,
+    results,
+  };
+}
+// === EIND: src/hooks/useToetsvormSearch.ts ===

--- a/Leerdoelengenerator-main/src/pages/toetsvormen.tsx
+++ b/Leerdoelengenerator-main/src/pages/toetsvormen.tsx
@@ -1,0 +1,31 @@
+// === BEGIN: anchors voorbeeld op toetsvormenpagina ===
+import { TOETSVORMEN } from "@/data/toetsvormen";
+
+export default function ToetsvormenPagina() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <h1 className="text-2xl font-bold">Toetsvormen</h1>
+      <div className="mt-6 space-y-8">
+        {TOETSVORMEN.map((t) => (
+          <section key={t.id} id={`toetsvorm-${t.id}`} className="scroll-mt-24">
+            <h2 className="text-xl font-semibold">{t.naam}</h2>
+            {t.beschrijving && <p className="mt-1 text-gray-700">{t.beschrijving}</p>}
+            <div className="mt-2 flex flex-wrap gap-2">
+              {t.categorieen.map((c) => (
+                <span key={c} className="rounded-full bg-gray-100 px-2.5 py-1 text-xs text-gray-800">
+                  {c}
+                </span>
+              ))}
+              {t.baan && (
+                <span className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs text-indigo-700">
+                  {t.baan}
+                </span>
+              )}
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}
+// === EIND: anchors voorbeeld op toetsvormenpagina ===


### PR DESCRIPTION
## Summary
- add a dataset of toetsvormen with categories, baan focus and validity metadata
- provide a reusable search hook and modal to filter toetsvormen by text, categorie and lane
- integrate the modal from the main header and add a linked toetsvormen page with anchor sections

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d68221b3d48330b448bbc8d5c55397