### PR TITLE
Update Vercel redirect to new domain

### DIFF
--- a/Leerdoelengenerator-main/vercel.json
+++ b/Leerdoelengenerator-main/vercel.json
@@ -4,7 +4,10 @@
   ],
   "redirects": [
     {
-      "source": "https://leerdoelen.digited.nl/(.*)",
+      "source": "/(.*)",
+      "has": [
+        { "type": "host", "value": "leerdoelen.digited.nl" }
+      ],
       "destination": "https://leerdoelen.edwinspielhagen.nl/$1",
       "permanent": true
     }


### PR DESCRIPTION
## Summary
- update the Vercel redirect so traffic from leerdoelen.digited.nl points to leerdoelen.edwinspielhagen.nl using a host matcher

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d68513cee48330b777af197dc1fb4e