### PR TITLE
Remove obsolete Vercel redirect

### DIFF
--- a/Leerdoelengenerator-main/vercel.json
+++ b/Leerdoelengenerator-main/vercel.json
@@ -1,12 +1,1 @@
-{
-  "redirects": [
-    {
-      "source": "/:path*",
-      "has": [
-        { "type": "host", "value": "leerdoelen.digited.nl" }
-      ],
-      "destination": "https://leerdoelen.edwinspielhagen.nl/:path*",
-      "permanent": true
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## Summary
- remove the Vercel redirect that forwarded traffic from leerdoelen.digited.nl

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d68f5713e08330889b9d5353e93748