### PR TITLE
Add new assessment forms and categories

### DIFF
--- a/Leerdoelengenerator-main/src/data/toetsvormen.ts
+++ b/Leerdoelengenerator-main/src/data/toetsvormen.ts
@@ -1,11 +1,3 @@
-export type ToetsCategorie =
-  | "Mondeling"
-  | "Schriftelijk"
-  | "Praktijk/Authentiek"
-  | "Proces/Portfolio"
-  | "Digitaal/Geautomatiseerd"
-  | "Peer/Co-assessment";
-
 export interface Toetsvorm {
   id: string;
   naam: string;
@@ -16,14 +8,21 @@ export interface Toetsvorm {
   betrouwbaarheidFocus?: "Hoog" | "Midden" | "Laag";
 }
 
-export const ALLE_CATEGORIEEN: ToetsCategorie[] = [
+export const ALLE_CATEGORIEEN = [
   "Mondeling",
   "Schriftelijk",
   "Praktijk/Authentiek",
   "Proces/Portfolio",
   "Digitaal/Geautomatiseerd",
   "Peer/Co-assessment",
-];
+  "Product-opdracht",
+  "Performance assessment",
+  "Portfolio",
+  "Mondelinge toets",
+  "Schriftelijke toets",
+] as const;
+
+export type ToetsCategorie = (typeof ALLE_CATEGORIEEN)[number];
 
 // 🎯 Voorbeeldset — vervang/uitbreid met jouw eigen lijst
 export const TOETSVORMEN: Toetsvorm[] = [
@@ -96,5 +95,170 @@ export const TOETSVORMEN: Toetsvorm[] = [
     baan: "Baan 2",
     validiteitFocus: "Midden",
     betrouwbaarheidFocus: "Midden",
+  },
+  {
+    id: "acties",
+    naam: "Acties",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "beroepsproducten-stageplek",
+    naam: "Beroepsproducten stageplek",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "beroepsproduct",
+    naam: "Beroepsproduct",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "casestudies",
+    naam: "Casestudies",
+    categorieen: ["Schriftelijke toets"],
+  },
+  {
+    id: "cognitive-interview-csi",
+    naam: "CSI (Cognitive Interview CSI)",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "diagnostisch",
+    naam: "Diagnostisch",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "eindproduct",
+    naam: "Eindproduct",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "essay-schriftelijke-toets",
+    naam: "Essay",
+    categorieen: ["Schriftelijke toets"],
+  },
+  {
+    id: "examen-performance",
+    naam: "Examen",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "feedback-performance",
+    naam: "Feedback",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "formative-performance-assessment",
+    naam: "Formative Performance assessment (FPA)",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "gespreksassessment",
+    naam: "Gespreksassessment",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "individuele-performance-assessment",
+    naam: "Individuele Performance assessment (IPA)",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "interview-performance",
+    naam: "Interview",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "mondelinge-toets",
+    naam: "Mondelinge toets",
+    categorieen: ["Mondelinge toets"],
+  },
+  {
+    id: "peer-performance-assessment",
+    naam: "Peer Performance assessment (PPA)",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "portfolio-toetsvorm",
+    naam: "Portfolio",
+    categorieen: ["Portfolio"],
+  },
+  {
+    id: "praktijk-performance-assessment",
+    naam: "Praktijk Performance assessment (PPA)",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "proeve-van-bekwaamheid",
+    naam: "Proeve van Bekwaamheid",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "project-product-opdracht",
+    naam: "Project",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "reflectie-product-opdracht",
+    naam: "Reflectie",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "reflectie-opdracht",
+    naam: "Reflectie-opdracht",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "rollenspellen",
+    naam: "Rollenspellen",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "spreektoetsen",
+    naam: "Spreektoetsen",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "stakeholders-performance-assessment",
+    naam: "Stakeholders Performance assessment (SPA)",
+    categorieen: ["Performance assessment"],
+  },
+  {
+    id: "taaltoetsen",
+    naam: "Taaltoetsen",
+    categorieen: ["Schriftelijke toets"],
+  },
+  {
+    id: "toetsgesprekken-mondeling",
+    naam: "Toetsgesprekken (mondeling)",
+    categorieen: ["Mondelinge toets"],
+  },
+  {
+    id: "toetsmateriaal",
+    naam: "Toetsmateriaal",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "toetsvorm",
+    naam: "Toetsvorm",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "verslag-product-opdracht",
+    naam: "Verslag",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "voortgangstoets",
+    naam: "Voortgangstoets",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "samtoets",
+    naam: "SamenToets",
+    categorieen: ["Product-opdracht"],
+  },
+  {
+    id: "vorm-in-overleg",
+    naam: "Vorm in overleg met student(en)",
+    categorieen: ["Product-opdracht"],
   },
 ];


### PR DESCRIPTION
## Summary
- extend the shared category list to include new toetsvorm-categorieën zoals Product-opdracht, Performance assessment en Mondelinge/Schriftelijke toets
- voeg de aangeleverde toetsvormen toe met unieke id's en hun bijbehorende categorie
- leid het ToetsCategorie-type automatisch af van de categorieënlijst voor consistentie

## Testing
- npm test *(faalt: vitest niet beschikbaar zonder install)*
- npm install *(faalt: npm 403 bij ophalen eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68d6906b68e88330bbe1b9f4691577f0