### PR TITLE
Improve toetsvorm search modal usability

### DIFF
--- a/Leerdoelengenerator-main/src/components/ToetsvormSearchModal.tsx
+++ b/Leerdoelengenerator-main/src/components/ToetsvormSearchModal.tsx
@@ -15,8 +15,6 @@ export default function ToetsvormSearchModal({ open, onClose }: Props) {
     setQuery,
     activeCats,
     toggleCat,
-    onlyBaan,
-    setOnlyBaan,
     categories,
     results,
   } = useToetsvormSearch();
@@ -33,7 +31,7 @@ export default function ToetsvormSearchModal({ open, onClose }: Props) {
 
   return (
     <div className="fixed inset-0 z-[100] flex items-start justify-center bg-black/50 p-4 md:p-8">
-      <div className="w-full max-w-4xl rounded-2xl bg-white p-4 md:p-6 shadow-xl">
+      <div className="w-full max-w-4xl rounded-2xl bg-white p-4 md:p-6 shadow-xl max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-xl md:text-2xl font-semibold">Zoek toetsvormen</h2>
           <button
@@ -57,47 +55,27 @@ export default function ToetsvormSearchModal({ open, onClose }: Props) {
         </div>
 
         {/* Filters */}
-        <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="md:col-span-2">
-            <p className="mb-2 text-sm font-medium text-gray-700">Categorieën</p>
-            <div className="flex flex-wrap gap-2">
-              {categories.map((c: ToetsCategorie) => {
-                const active = activeCats.includes(c);
-                return (
-                  <button
-                    key={c}
-                    onClick={() => toggleCat(c)}
-                    className={[
-                      "rounded-full border px-3 py-1 text-sm",
-                      active
-                        ? "border-indigo-600 bg-indigo-600 text-white"
-                        : "border-gray-300 bg-white text-gray-800 hover:bg-gray-50",
-                    ].join(" ")}
-                    aria-pressed={active}
-                  >
-                    {c}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
-          <div>
-            <p className="mb-2 text-sm font-medium text-gray-700">Two-Lane (optioneel)</p>
-            <select
-              value={onlyBaan}
-              onChange={(e) =>
-                setOnlyBaan(
-                  e.target.value as "" | "Baan 1" | "Baan 2" | "Beide"
-                )
-              }
-              className="w-full rounded-xl border border-gray-300 px-3 py-2 outline-none focus:ring-2 focus:ring-indigo-500"
-            >
-              <option value="">Alle</option>
-              <option value="Baan 1">Baan 1</option>
-              <option value="Baan 2">Baan 2</option>
-              <option value="Beide">Beide</option>
-            </select>
+        <div className="mt-4">
+          <p className="mb-2 text-sm font-medium text-gray-700">Categorieën</p>
+          <div className="flex flex-wrap gap-2">
+            {categories.map((c: ToetsCategorie) => {
+              const active = activeCats.includes(c);
+              return (
+                <button
+                  key={c}
+                  onClick={() => toggleCat(c)}
+                  className={[
+                    "rounded-full border px-3 py-1 text-sm",
+                    active
+                      ? "border-indigo-600 bg-indigo-600 text-white"
+                      : "border-gray-300 bg-white text-gray-800 hover:bg-gray-50",
+                  ].join(" ")}
+                  aria-pressed={active}
+                >
+                  {c}
+                </button>
+              );
+            })}
           </div>
         </div>
 
@@ -127,11 +105,6 @@ export default function ToetsvormSearchModal({ open, onClose }: Props) {
                           {c}
                         </span>
                       ))}
-                      {t.baan && (
-                        <span className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs text-indigo-700">
-                          {t.baan}
-                        </span>
-                      )}
                     </div>
                   </div>
                   {/* 👉 Voorzie van jouw eigen deep-link of actie */}

--- a/Leerdoelengenerator-main/src/data/toetsvormen.ts
+++ b/Leerdoelengenerator-main/src/data/toetsvormen.ts
@@ -32,7 +32,6 @@ export const TOETSVORMEN: Toetsvorm[] = [
     beschrijving:
       "Individuele mondelinge bevraging met doorvragen op begrip en toepassing.",
     categorieen: ["Mondeling"],
-    baan: "Baan 1",
     validiteitFocus: "Hoog",
     betrouwbaarheidFocus: "Midden",
   },
@@ -52,7 +51,6 @@ export const TOETSVORMEN: Toetsvorm[] = [
     beschrijving:
       "Schriftelijke uitwerking met nadruk op redenering, bronnen en structuur.",
     categorieen: ["Schriftelijk"],
-    baan: "Baan 1",
     validiteitFocus: "Midden",
     betrouwbaarheidFocus: "Midden",
   },
@@ -82,7 +80,6 @@ export const TOETSVORMEN: Toetsvorm[] = [
     beschrijving:
       "MC/gesloten vragen met automatische scoring en item-analyse.",
     categorieen: ["Digitaal/Geautomatiseerd"],
-    baan: "Baan 1",
     validiteitFocus: "Midden",
     betrouwbaarheidFocus: "Hoog",
   },
@@ -92,7 +89,6 @@ export const TOETSVORMEN: Toetsvorm[] = [
     beschrijving:
       "Studenten beoordelen elkaars werk aan de hand van heldere criteria/rubrics.",
     categorieen: ["Peer/Co-assessment", "Proces/Portfolio"],
-    baan: "Baan 2",
     validiteitFocus: "Midden",
     betrouwbaarheidFocus: "Midden",
   },

--- a/Leerdoelengenerator-main/src/hooks/useToetsvormSearch.ts
+++ b/Leerdoelengenerator-main/src/hooks/useToetsvormSearch.ts
@@ -5,7 +5,6 @@ import { TOETSVORMEN, ALLE_CATEGORIEEN, Toetsvorm, ToetsCategorie } from "@/data
 export function useToetsvormSearch() {
   const [query, setQuery] = useState("");
   const [activeCats, setActiveCats] = useState<ToetsCategorie[]>([]);
-  const [onlyBaan, setOnlyBaan] = useState<"Baan 1" | "Baan 2" | "Beide" | "">("");
 
   const results = useMemo<Toetsvorm[]>(() => {
     const q = query.trim().toLowerCase();
@@ -22,12 +21,9 @@ export function useToetsvormSearch() {
         activeCats.length === 0 ||
         activeCats.every((c) => t.categorieen.includes(c));
 
-      // baan-filter (optioneel)
-      const matchBaan = !onlyBaan || t.baan === onlyBaan || (onlyBaan === "Beide" && t.baan === "Beide");
-
-      return matchText && matchCats && matchBaan;
+      return matchText && matchCats;
     }).sort((a, b) => a.naam.localeCompare(b.naam));
-  }, [query, activeCats, onlyBaan]);
+  }, [query, activeCats]);
 
   function toggleCat(cat: ToetsCategorie) {
     setActiveCats((prev) =>
@@ -40,8 +36,6 @@ export function useToetsvormSearch() {
     setQuery,
     activeCats,
     toggleCat,
-    onlyBaan,
-    setOnlyBaan,
     categories: ALLE_CATEGORIEEN,
     results,
   };


### PR DESCRIPTION
## Summary
- allow the toetsvorm search modal to scroll within the viewport to reach all content
- simplify the filter section by removing the two-lane selection and related UI
- remove Baan 1/Baan 2 assignments from sample toetsvorm data to match the new behaviour

## Testing
- npm install *(fails: 403 Forbidden while fetching eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68d691f3f3fc8330aeab1e9814229487