### PR TITLE
Add Gemini availability health log

### DIFF
--- a/Leerdoelengenerator-main/src/services/gemini.ts
+++ b/Leerdoelengenerator-main/src/services/gemini.ts
@@ -145,7 +145,11 @@ export async function checkGeminiAvailable(): Promise<boolean> {
       generationConfig: { temperature: 0.1, maxOutputTokens: 8 }
     });
     const txt = res.response.text().trim();
-    return txt.toUpperCase().includes("OK");
+    const ok = txt.toUpperCase().includes("OK");
+    if (ok) {
+      console.info("[AI-check] Gemini online met model:", MODEL_NAME);
+    }
+    return ok;
   } catch (e) {
     console.error("[gemini] Beschikbaarheidscheck faalde:", e);
     return false;


### PR DESCRIPTION
## Summary
- log the model identifier whenever the Gemini availability check succeeds to confirm the active configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69db0f57083309f0ee41c7614e894