### PR TITLE
Refactor Gemini integration to AI Studio route

### DIFF
--- a/Leerdoelengenerator-main/api/gemini-generate.ts
+++ b/Leerdoelengenerator-main/api/gemini-generate.ts
@@ -1,0 +1,15 @@
+// api/gemini-generate.ts
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { generateText } from "../services/gemini";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const { prompt } = (req.method === "POST" ? req.body : req.query) as { prompt: string };
+    if (!prompt) return res.status(400).json({ error: "Missing prompt" });
+    const text = await generateText(prompt);
+    return res.status(200).json({ text, provider: "ai-studio", model: process.env.GEMINI_MODEL_ID || "gemini-1.5-flash" });
+  } catch (e: any) {
+    console.error("[Gemini] error", e?.message || e);
+    return res.status(500).json({ error: "Gemini failed", detail: e?.message || String(e) });
+  }
+}

--- a/Leerdoelengenerator-main/services/gemini.ts
+++ b/Leerdoelengenerator-main/services/gemini.ts
@@ -1,0 +1,26 @@
+// services/gemini.ts
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+const MODEL = process.env.GEMINI_MODEL_ID || "gemini-1.5-flash";
+
+function assertEnv(name: string) {
+  const v = process.env[name];
+  if (!v) throw new Error(`[Gemini] Missing env ${name}`);
+  return v;
+}
+
+export function getGeminiModel() {
+  const apiKey = assertEnv("GOOGLE_API_KEY");
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({ model: MODEL });
+  console.info("[AI-check] Gemini online met model:", MODEL);
+  return model;
+}
+
+export async function generateText(prompt: string) {
+  const model = getGeminiModel();
+  const res = await model.generateContent({
+    contents: [{ role: "user", parts: [{ text: prompt }]}],
+  });
+  return res.response.text();
+}


### PR DESCRIPTION
## Summary
- add a reusable Gemini AI Studio client under services/gemini.ts
- expose a new /api/gemini-generate route that proxies prompts through AI Studio
- update the Gemini front-end service and UI flow to call the internal route and track availability state

## Testing
- npm run lint *(fails: missing @eslint/js package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a1e71a588330a42287062cd72687