### PR TITLE
Update Gemini route environment variable handling

### DIFF
--- a/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
+++ b/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
@@ -3,7 +3,15 @@ import { NextRequest, NextResponse } from "next/server";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const MODEL_ID = process.env.GEMINI_MODEL_ID || "gemini-1.5-flash";
+const API_KEY =
+  process.env.GOOGLE_API_KEY ||
+  process.env.GEMINI_API_KEY ||
+  process.env.VITE_GEMINI_API_KEY;
+
+const MODEL_ID =
+  process.env.GEMINI_MODEL_ID ||
+  process.env.VITE_GEMINI_MODEL ||
+  "gemini-1.5-flash";
 
 type GeminiRequestBody = { prompt?: string } | null;
 
@@ -25,10 +33,9 @@ type GeminiResponseBody = {
 
 export async function POST(req: NextRequest) {
   try {
-    const apiKey = process.env.GOOGLE_API_KEY;
-    if (!apiKey) {
+    if (!API_KEY) {
       return NextResponse.json(
-        { error: "Missing GOOGLE_API_KEY on server" },
+        { error: "Missing Gemini API key on server" },
         { status: 500 }
       );
     }
@@ -42,7 +49,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Missing prompt" }, { status: 400 });
     }
 
-    const url = `https://generativelanguage.googleapis.com/v1/models/${MODEL_ID}:generateContent?key=${apiKey}`;
+    const url = `https://generativelanguage.googleapis.com/v1/models/${MODEL_ID}:generateContent?key=${API_KEY}`;
 
     const payload = {
       contents: [{ role: "user", parts: [{ text: prompt }]}],


### PR DESCRIPTION
## Summary
- add API key and model fallbacks so the Gemini route accepts multiple environment variable names
- return a clearer error when the Gemini API key is missing and use the resolved key in the request URL

## Testing
- `npm run lint` *(fails: missing dependency @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b5a39e208330bb5f92a0aa080096