### PR TITLE
Fix Gemini API key detection on Gemini route

### DIFF
--- a/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
+++ b/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
@@ -12,7 +12,11 @@ function trimToMaxChars(text: string, max = 120_000) {
 
 export async function POST(req: Request) {
   try {
-    const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+    const apiKey =
+      process.env.GEMINI_API_KEY ||
+      process.env.GOOGLE_API_KEY ||
+      process.env.VITE_GEMINI_API_KEY ||
+      process.env.NEXT_PUBLIC_GEMINI_API_KEY;
     if (!apiKey) {
       return new Response(
         JSON.stringify({ ok: false, error: 'Missing GEMINI_API_KEY' }),


### PR DESCRIPTION
## Summary
- allow the Gemini route to read keys from all configured environment variables
- ensure deployments using VITE_/NEXT_PUBLIC_ prefixed keys no longer fall back to the offline generator

## Testing
- npm test *(fails: vitest binary unavailable before install)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cb05d174833096f515048b92a538