### PR TITLE
Add Gemini API route and helper improvements

### DIFF
--- a/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
+++ b/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
@@ -1,3 +1,4 @@
+// Forceer Node-runtime om Edge-issues te vermijden
 export const runtime = 'nodejs';
 
 const ENDPOINT =
@@ -15,10 +16,7 @@ export async function POST(req: Request) {
 
     const body = await req.json().catch(() => ({}));
     const prompt: string = body?.prompt ?? 'Health check: zeg “OK”.';
-
-    const payload = {
-      contents: [{ role: 'user', parts: [{ text: prompt }] }],
-    };
+    const payload = { contents: [{ role: 'user', parts: [{ text: prompt }] }] };
 
     const r = await fetch(`${ENDPOINT}?key=${apiKey}`, {
       method: 'POST',
@@ -27,7 +25,6 @@ export async function POST(req: Request) {
     });
 
     const upstreamText = await r.text();
-
     if (!r.ok) {
       return new Response(
         JSON.stringify({ ok: false, upstreamStatus: r.status, upstream: upstreamText.slice(0, 2000) }),
@@ -41,7 +38,7 @@ export async function POST(req: Request) {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (e: any) {
-    return new Response(JSON.stringify({ ok: false, error: 'Route crashed', detail: e?.message }), {
+    return new Response(JSON.stringify({ ok: false, error: 'Route crashed', detail: String(e) }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/Leerdoelengenerator-main/lib/gemini.ts
+++ b/Leerdoelengenerator-main/lib/gemini.ts
@@ -1,6 +1,12 @@
 // lib/gemini.ts
+function apiUrl(path: string) {
+  // Ondersteun basePath; zet NEXT_PUBLIC_BASE_PATH gelijk aan basePath in next.config.js (of laat leeg)
+  const bp = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  return `${bp}/api${path.startsWith('/') ? path : `/${path}`}`;
+}
+
 export async function callGemini(prompt: string, system?: string) {
-  const res = await fetch('/api/gemini-generate', {
+  const res = await fetch(apiUrl('/gemini-generate'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ prompt, system }),
@@ -9,12 +15,8 @@ export async function callGemini(prompt: string, system?: string) {
   const json = await res.json().catch(() => ({}));
 
   if (!json?.ok) {
-    // Toon nette, bruikbare fout in console/UI i.p.v. 502/Object
     console.error('[Gemini error]', json);
-    const msg =
-      json?.upstream ??
-      json?.error ??
-      `Gemini call failed (status: ${json?.upstreamStatus ?? 'unknown'})`;
+    const msg = json?.upstream || json?.error || `Gemini call failed`;
     throw new Error(typeof msg === 'string' ? msg : JSON.stringify(msg));
   }
 


### PR DESCRIPTION
## Summary
- align the Gemini generate API route with the expected error handling and runtime configuration
- add a shared Gemini client helper that respects optional basePath configuration

## Testing
- `npm test` *(fails: vitest command not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d53fad3483309273462734cb62b3