### PR TITLE
Log Gemini API responses in backend route

### DIFF
--- a/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
+++ b/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
@@ -33,6 +33,7 @@ export async function POST(req: Request) {
     }
 
     const data = JSON.parse(upstreamText);
+    console.log('Gemini response:', data);
     return new Response(JSON.stringify({ ok: true, data }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- log the parsed Gemini API response in the gemini-generate backend route for easier verification

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8087c9d48330ae5702d4c1fa13f5