### PR TITLE
feat: add Gemini server proxy route

### DIFF
--- a/Leerdoelengenerator-main/api/diag/env.ts
+++ b/Leerdoelengenerator-main/api/diag/env.ts
@@ -1,0 +1,6 @@
+// api/diag/env.ts
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default function handler(_req: VercelRequest, res: VercelResponse) {
+  res.status(200).json({ geminiKeyPresent: Boolean(process.env.GEMINI_API_KEY) });
+}

--- a/Leerdoelengenerator-main/api/gemini.ts
+++ b/Leerdoelengenerator-main/api/gemini.ts
@@ -1,0 +1,33 @@
+// api/gemini.ts
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const key = process.env.GEMINI_API_KEY;
+  if (!key) {
+    return res.status(500).json({ error: 'GEMINI_API_KEY is missing on server' });
+  }
+
+  try {
+    const { prompt } = (req.body ?? {}) as { prompt?: string };
+    if (!prompt || typeof prompt !== 'string') {
+      return res.status(400).json({ error: 'Missing prompt' });
+    }
+
+    const genAI = new GoogleGenerativeAI(key);
+    const model = genAI.getGenerativeModel({ model: 'gemini-1.5-pro' });
+
+    const result = await model.generateContent(prompt);
+    const text = result?.response?.text?.() ?? '';
+
+    return res.status(200).json({ text });
+  } catch (err: any) {
+    console.error('[gemini] error:', err?.message || err);
+    return res.status(500).json({ error: 'Gemini request failed' });
+  }
+}

--- a/Leerdoelengenerator-main/package-lock.json
+++ b/Leerdoelengenerator-main/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@google/generative-ai": "^0.18.0",
         "docx": "^8.5.0",
         "file-saver": "^2.0.5",
         "jspdf": "^2.5.1",

--- a/Leerdoelengenerator-main/package.json
+++ b/Leerdoelengenerator-main/package.json
@@ -13,6 +13,7 @@
     "test:ui": "vitest"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.18.0",
     "docx": "^8.5.0",
     "file-saver": "^2.0.5",
     "jspdf": "^2.5.1",

--- a/Leerdoelengenerator-main/src/services/gemini.ts
+++ b/Leerdoelengenerator-main/src/services/gemini.ts
@@ -23,7 +23,7 @@ export interface KDContext {
   relatedWorkProcesses?: Array<{ title: string }>;
 }
 
-const GEMINI_ROUTE = "/api/gemini-generate";
+const GEMINI_ROUTE = "/api/gemini";
 let lastAvailable = false;
 
 /**


### PR DESCRIPTION
## Summary
- add a dedicated `/api/gemini` Vercel function that reads the server-side GEMINI_API_KEY and proxies prompts via the Google Generative AI SDK
- expose a diagnostics route to confirm whether the Gemini key is present in the deployment environment
- refactor the client Gemini helper to call the new API route and depend on the SDK package

## Testing
- not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e00d04de4c8330b223573668841d80