### PR TITLE
Add safe AI response parsing

### DIFF
--- a/Leerdoelengenerator-main/api/gemini-generate.ts
+++ b/Leerdoelengenerator-main/api/gemini-generate.ts
@@ -1,5 +1,6 @@
 // api/gemini-generate.ts
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { parseAIResponse } from '../src/utils/aiResponse';
 
 const ENDPOINT =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent';
@@ -54,8 +55,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     const data = JSON.parse(upstreamText);
+    const text = parseAIResponse((data as any)?.response ?? data);
     res.setHeader('Access-Control-Allow-Origin', '*');
-    res.status(200).json({ ok: true, data });
+    res.status(200).json({ ok: true, data, text });
   } catch (err: any) {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.status(200).json({

--- a/Leerdoelengenerator-main/api/gemini.ts
+++ b/Leerdoelengenerator-main/api/gemini.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { parseAIResponse } from '../src/utils/aiResponse';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
@@ -35,7 +36,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       },
     });
 
-    const text = result?.response?.text?.() ?? '';
+    const text = parseAIResponse(result?.response ?? result);
     return res.status(200).json({ text });
   } catch (err: any) {
     console.error('[gemini] error:', err?.message || err);

--- a/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
+++ b/Leerdoelengenerator-main/app/api/gemini-generate/route.ts
@@ -1,3 +1,5 @@
+import { parseAIResponse } from '@/utils/aiResponse';
+
 // Forceer Node-runtime om Edge-issues te vermijden
 export const runtime = 'nodejs';
 
@@ -33,7 +35,8 @@ export async function POST(req: Request) {
     }
 
     const data = JSON.parse(upstreamText);
-    return new Response(JSON.stringify({ ok: true, data }), {
+    const text = parseAIResponse((data as any)?.response ?? data);
+    return new Response(JSON.stringify({ ok: true, data, text }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/Leerdoelengenerator-main/src/lib/gemini.ts
+++ b/Leerdoelengenerator-main/src/lib/gemini.ts
@@ -1,3 +1,5 @@
+import { parseAIResponse } from '@/utils/aiResponse';
+
 const GEMINI_ROUTE = '/api/gemini';
 
 export async function askGeminiFlash(prompt: string): Promise<string> {
@@ -8,5 +10,8 @@ export async function askGeminiFlash(prompt: string): Promise<string> {
   });
   const data = await r.json();
   if (!r.ok) throw new Error(data?.error || `Gemini route failed (${r.status})`);
-  return data?.text ?? '';
+  if (typeof data?.text === 'string' && data.text.trim()) {
+    return data.text;
+  }
+  return parseAIResponse(data?.data ?? data);
 }

--- a/Leerdoelengenerator-main/src/utils/aiResponse.ts
+++ b/Leerdoelengenerator-main/src/utils/aiResponse.ts
@@ -1,0 +1,64 @@
+export function parseAIResponse(response: unknown): string {
+  console.log("AI API response:", response);
+
+  if (!response) return "⚠️ Geen antwoord ontvangen van AI.";
+
+  if (typeof response === "object" && response !== null) {
+    const maybeChoices = (response as any).choices;
+    if (Array.isArray(maybeChoices) && maybeChoices.length > 0) {
+      return (
+        maybeChoices[0]?.message?.content || "⚠️ Leeg antwoord (OpenAI)."
+      );
+    }
+  }
+
+  if (typeof response === "object" && response !== null) {
+    const candidates = (response as any).candidates;
+    if (Array.isArray(candidates) && candidates.length > 0) {
+      const firstCandidate = candidates[0];
+      const parts = firstCandidate?.content?.parts;
+      if (Array.isArray(parts) && parts.length > 0) {
+        const firstPart = parts[0];
+        if (
+          firstPart &&
+          typeof firstPart.text === "string" &&
+          firstPart.text.trim()
+        ) {
+          return firstPart.text;
+        }
+      }
+      if (
+        typeof firstCandidate?.text === "string" &&
+        firstCandidate.text.trim()
+      ) {
+        return firstCandidate.text;
+      }
+      return "⚠️ Leeg antwoord (Gemini).";
+    }
+  }
+
+  if (
+    typeof response === "object" &&
+    response !== null &&
+    typeof (response as any).text === "function"
+  ) {
+    try {
+      const value = (response as any).text();
+      if (typeof value === "string" && value.trim()) {
+        return value;
+      }
+    } catch (error) {
+      console.error("Fout bij aanroepen van response.text():", error);
+    }
+  } else if (
+    typeof response === "object" &&
+    response !== null &&
+    typeof (response as any).text === "string" &&
+    (response as any).text.trim()
+  ) {
+    return (response as any).text;
+  }
+
+  console.error("Onbekend AI-responseformaat:", response);
+  return "⚠️ Onbekende AI-response structuur.";
+}


### PR DESCRIPTION
## Summary
- add a shared `parseAIResponse` helper that safely extracts text from OpenAI- and Gemini-style payloads with debug logging
- reuse the parser across Gemini API routes and the frontend client helper so unexpected shapes no longer throw type errors and still return fallback messages

## Testing
- npm test *(fails: vitest binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d53e5aac8330b1fdebbbe689efdf